### PR TITLE
Fix  --iso

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -18,9 +18,15 @@
 
 # use aptitude only if it's available
 if [ -x /usr/bin/aptitude ] ; then
-   APTINSTALL="aptitude -y --without-recommends install $DPKG_OPTIONS"
    APTUPDATE='aptitude update'
-   APTUPGRADE='aptitude -y safe-upgrade'
+   # Debian ISOs do not contain signed Release files
+   if [ -n "$ISO" ] ; then
+      APTINSTALL="aptitude -y --allow-untrusted --without-recommends install $DPKG_OPTIONS"
+      APTUPGRADE='aptitude -y --allow-untrusted safe-upgrade'
+   else
+      APTINSTALL="aptitude -y --without-recommends install $DPKG_OPTIONS"
+      APTUPGRADE='aptitude -y safe-upgrade'
+   fi
 else
    APTINSTALL="apt-get --force-yes -y --no-install-recommends install $DPKG_OPTIONS"
    APTUPDATE='apt-get update'

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -853,6 +853,12 @@ ISODIR=${ISO##file:}
 ISODIR=${ISODIR%%/}
 # }}}
 
+# Debian ISOs do not contain signed Release files {{{
+if [ -n "$ISO" ] ; then
+    DEBOOTSTRAP_OPT="$DEBOOTSTRAP_OPT --no-check-gpg"
+fi
+# }}}
+
 # create filesystem {{{
 mkfs() {
   if [ -n "$DIRECTORY" ] ; then


### PR DESCRIPTION
Using --iso /some/mounted/iso is currently broken in several ways:
- when passing /path and not file:/path, the path gets mangled (file:/ is needed by debootstrap/apt)
- debootstrap is never called with the path to the iso, as it only does that when MIRROR is not set, which never happens
- Debian ISOs do not contain signed Release files (instead the ISOs are signed), thus debootstrap fails and needs --no-check-gpg
- same applies to aptitude which needs --allow-untrusted in this case (apt-get already uses --force-yes)
