### PR TITLE
Remove Debian release codenames (Closes: #688234)

### DIFF
--- a/config
+++ b/config
@@ -63,10 +63,11 @@
 # GRMLPACKAGES='grml-etc-core'
 
 # Debian release that should be installed.
-# Supported values: lenny (old-stable), squeeze (stable),
-#                   wheezy (testing), sid (unstable)
-# Default: 'squeeze'
-# RELEASE='squeeze'
+# Supported values: the current, the previous and the next Debian
+#                   release codenames as well as their aliases
+#                   (oldstable, stable, testing), and unstable.
+# Default: 'stable'
+# RELEASE='stable'
 
 # Define components that should be used within sources.list.
 # Default: 'main contrib non-free'

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -31,7 +31,7 @@ MKFS='mkfs.ext3'
 PACKAGES='yes'
 PRE_SCRIPTS='yes'
 RECONFIGURE='console-data'
-RELEASE='squeeze'
+RELEASE='stable'
 RM_APTCACHE='yes'
 SCRIPTS='yes'
 SECURE='yes'
@@ -60,7 +60,7 @@ Bootstrap options:
   -m, --mirror <URL>     Mirror which should be used for apt-get/aptitude.
   -i, --iso <mnt>        Mountpoint where a Debian ISO is mounted to, for use
                          instead of fetching packages from a mirror.
-  -r, --release <name>   Release of new Debian system (default: squeeze).
+  -r, --release <name>   Release of new Debian system (default: stable).
   -t, --target <target>  Target partition (/dev/...) or directory where the
                          system should be installed to.
   -p, --mntpoint <mnt>   Mountpoint used for mounting the target system,
@@ -494,14 +494,14 @@ prompt_for_bootmanager()
 # ask for Debian release {{{
 prompt_for_release()
 {
-  [ -n "$RELEASE" ] && DEFAULT_RELEASE="$RELEASE" || DEFAULT_RELEASE='squeeze'
+  [ -n "$RELEASE" ] && DEFAULT_RELEASE="$RELEASE" || DEFAULT_RELEASE='stable'
   RELEASE="$(dialog --stdout --title "${PN}" --default-item $DEFAULT_RELEASE --menu \
             "Please enter the Debian release you would like to use for installation:" \
             0 50 4 \
-            lenny    Debian/old-stable \
-            squeeze  Debian/stable \
-            wheezy   Debian/testing \
-            sid      Debian/unstable)"
+            stable    \
+            testing   \
+            sid       (unstable)\
+            oldstable)"
   [ $? -eq 0 ] || bailout
 }
 # }}}

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -149,8 +149,8 @@ Options and environment variables
 
 *-r*, *--release* _releasename_::
 
-    Specify release of new Debian system. Supported releases names: lenny,
-    squeeze, wheezy (note: requires current version of debootstrap) and sid.
+    Specify release of new Debian system. Supported releases names: stable,
+    testing, sid and oldstable.
     Corresponding with configuration variable RELEASE.
 
 *--pre-scripts* _directory_::
@@ -201,7 +201,7 @@ Usage examples
 
   grml-debootstrap --target /dev/sda1 --grub /dev/sda
 
-Install default Debian release (stable/squeeze) on /dev/sda1 and install bootmanager
+Install default Debian release (stable) on /dev/sda1 and install bootmanager
 Grub in MBR (master boot record) of /dev/sda and use /dev/sda1 as system partition.
 
   grml-debootstrap --target /dev/sda6 --grub /dev/sda --release sid
@@ -212,25 +212,25 @@ Install Debian unstable/sid on /dev/sda6, install bootmanager Grub in MBR
   mount /dev/sda1 /data/chroot
   grml-debootstrap --target /data/chroot
 
-Install default Debian release (stable/squeeze) in directory /data/chroot (without
+Install default Debian release (stable) in directory /data/chroot (without
 any bootloader).
 
   grml-debootstrap --target /dev/sda3 --grub /dev/sda  --mirror ftp://ftp.tugraz.at/mirror/debian
 
-Install default debian release (stable/squeeze) in a Virtual Machine file with
+Install default debian release (stable) in a Virtual Machine file with
 3GB disk size (including Grub as bootmanager in MBR of the virtual disk file):
 
   mount /dev/sda1 /mnt/sda1
   grml-debootstrap --vmfile --vmsize 3G --target /mnt/sda1/qemu.img
 
-Install default Debian release (stable/squeeze) on /dev/sda3 and install bootmanager
+Install default Debian release (stable) on /dev/sda3 and install bootmanager
 Grub in MBR (master boot record) of /dev/sda and use /dev/sda3 as system partition.
 Use specified mirror instead of the default (ftp://ftp.debian.de/debian) one.
 
   mount -o loop /mnt/sda6/debian-40r0-i386-CD-1.iso /mnt/iso
   grml-debootstrap --target /dev/sda1 --grub /dev/sda --iso file:/mnt/iso/debian/
 
-Install Debian stable/squeeze on /dev/sda1 using the loopback mounted Debian-ISO
+Install Debian stable on /dev/sda1 using the loopback mounted Debian-ISO
 for the base-system and install bootmanager Grub in MBR (master boot record) of
 /dev/sda and use /dev/sda1 as system partition. Please notice, that the chroot
 system requires network access for all packages which are not part of the
@@ -311,8 +311,8 @@ Where do you want to install grub to? Usage example: grub=/dev/sda
 
   release=...
 
-Specify release of new Debian system. Defaults to Debian squeeze. Supported
-relases: lenny, squeeze, wheezy and sid. Usage example: release=sid
+Specify release of new Debian system. Defaults to Debian stable. Supported
+relases: oldstable, stable, testing and sid. Usage example: release=sid
 
   mirror=...
 
@@ -349,8 +349,8 @@ include::releasetable.txt[]
 .lenny release
 ================================================================================
 [1] Please notice that lenny is the current old-stable release within Debian.
-grml-debootstrap can handle the release but you really should not use lenny
-anymore unless you really know what you are doing. Choose stable (squeeze)
+grml-debootstrap can handle the release but you really should not use oldstable
+anymore unless you really know what you are doing. Choose stable
 instead.
 
 Notice that you need to specify a mirror providing the lenny release, the
@@ -367,8 +367,8 @@ the advantage of grub-legacy actually being able to boot from it.
 .sid release
 ================================================================================
 [2] Please notice that sid is Debian/unstable and due to its nature might not be
-always installable. What _might_ work instead is deploying stable (squeeze) or
-testing (wheezy) and upgrade it after installation finished.
+always installable. What _might_ work instead is deploying stable or testing
+and upgrade it after installation finished.
 ================================================================================
 
 Bugs


### PR DESCRIPTION
Completely untested patch that removes the codenames from the configuration, script and docs.

You might also want to "backport" this onto the version in testing.
