### PR TITLE
break on attempt to build amd64 on i386

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -792,6 +792,16 @@ else
 fi
 # }}}
 
+# It is not possible to build amd64 on i686. {{{
+CURRENT_ARCH="$(uname -m)"
+if [ "$CURRENT_ARCH" != "x86_64" ] ; then
+   if [ "$ARCH" = "amd64" ] ; then
+      eerror "It is not possible to build amd64 on $CURRENT_ARCH." ; eend 1
+      bailout 1
+   fi
+fi
+# }}}
+
 checkconfiguration
 
 # finally make sure at least $TARGET is set [the partition for the new system] {{{


### PR DESCRIPTION
This isn't possible. (At least not for VM images.) Normally, I know this. But I lost some time to figure out what I just attempted myself.

If it doesn't break on attempt to build amd64 on i386 at that point, you'll later get an `mount unknown executable format` (or something like that) error, which isn't trivial to make head or tail of.

Please check if this commit is sane.
