### PR TITLE
fixed disk identifiers

### DIFF
--- a/config
+++ b/config
@@ -201,4 +201,9 @@
 # Default: '/etc/debootstrap/install_notes' (empty file).
 # INSTALL_NOTES='/etc/debootstrap/install_notes'
 
+# Use fixed disk identifiers for Virtual Machine builds.
+# Useful for reproducible builds.
+# Default: 'no'
+# FIXEDDISKIDENTIFIERS='yes'
+
 ## END OF FILE #################################################################

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -39,6 +39,7 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$TUNE2FS" ] || TUNE2FS='tune2fs -c0 -i0'
 [ -n "$UPGRADE_SYSTEM" ] || UPGRADE_SYSTEM='yes'
 [ -n "$VMSIZE" ] || VMSIZE="2G"
+[ -n "$FIXEDDISKIDENTIFIERS" ] || FIXEDDISKIDENTIFIERS="no"
 
 # inside the chroot system locales might not be available, so use minimum:
 export LANG=C
@@ -887,6 +888,11 @@ mkfs() {
        einfo "Running $MKFS on $TARGET"
        $MKFS $TARGET ; RC=$?
 
+       if [ "$FIXEDDISKIDENTIFIERS" = "yes" ]; then
+          einfo "Changing disk uuid $TARGET using tune2fs"
+          tune2fs $TARGET -U 26ada0c0-1165-4098-884d-aafd2220c2c6
+       fi
+
        # make sure /dev/disk/by-uuid/... is up2date, otherwise grub
        # will fail to detect the uuid in the chroot
        if echo "$TARGET" | grep -q "/dev/md" ; then
@@ -961,6 +967,12 @@ prepare_vm() {
   qemu-img create -f raw "${TARGET}" "${VMSIZE}"
   echo 4 66 | /usr/share/grml-debootstrap/bootgrub.mksh -A | dd of="$TARGET" conv=notrunc
   dd if=/dev/zero bs=1 conv=notrunc count=64 seek=446 of="$TARGET"
+  if [ "$FIXEDDISKIDENTIFIERS" = "yes" ]; then
+    MBRTMPFILE=$(mktemp)
+    dd if="${TARGET}" of="${MBRTMPFILE}" bs=512 count=1
+    echo -en "\x41\x41\x41\x41\x41" | dd of="${MBRTMPFILE}" conv=notrunc seek=440 bs=1
+    dd if="${MBRTMPFILE}" of="${TARGET}" conv=notrunc
+  fi
   parted -s "${TARGET}" 'mkpart primary ext3 2M -1'
 
   # if dm-mod isn't available then kpartx will fail with


### PR DESCRIPTION
This is useful for [Reproducible Builds](https://wiki.debian.org/ReproducibleBuilds) / [ Verifiable Builds ](https://www.whonix.org/wiki/Verifiable_Builds).

This change does nothing by default. Otherwise, once the `FIXEDDISKIDENTIFIERS` environment variable is set to `yes`, it will change the disk signature and uuid of the vmfile to fixed values.
