### PR TITLE
Fix smbfs example in fstab

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -466,7 +466,7 @@ proc           /proc        proc    defaults                      0   0
 # some other examples:
 # /dev/sda2       none         swap    sw,pri=0             0   0
 # /dev/hda1       /Grml        ext3    dev,suid,user,noauto 0  2
-# //1.2.3.4/pub   /smb/pub     smbfs   defaults,user,noauto,uid=grml,gid=grml 0 0
+# //1.2.3.4/pub   /smb/pub     cifs    user,noauto,uid=grml,gid=grml 0 0
 # linux:/pub      /beer        nfs     defaults             0  0
 # tmpfs           /tmp         tmpfs   size=300M            0  0
 # /dev/sda5       none         swap    sw                   0  0


### PR DESCRIPTION
mount.smbfs is apparently gone, and mount.cifs doesn't understand "defaults" any more.
