### PR TITLE
basic syntax check

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -6,6 +6,8 @@
 # License:       This file is licensed under the GPL v2+
 ################################################################################
 
+bash -n "$0" || exit 1
+
 # variables {{{
 PN="$(basename $0)"
 VERSION="$(dpkg-query --show --showformat='${Version}' "$PN")"
@@ -1185,6 +1187,8 @@ preparechroot() {
   [ -n "$TUNE2FS" ]             && echo "TUNE2FS=\"$TUNE2FS\""                         >> $CHROOT_VARIABLES
   [ -n "$VMSIZE" ]              && echo "VMSIZE=\"$VMSIZE\""                           >> $CHROOT_VARIABLES
 
+  bash -n $CONFFILES/chroot-script
+  eend $?
   cp $VERBOSE $CONFFILES/chroot-script $MNTPOINT/bin/chroot-script
   chmod 755 $MNTPOINT/bin/chroot-script
   [ -d "$MNTPOINT"/etc/debootstrap/ ] || mkdir "$MNTPOINT"/etc/debootstrap/


### PR DESCRIPTION
Run `grml-debootstrap` and `chroot-script` through `bash -n` as basic syntax check before proceeding.
