### PR TITLE
Use UUIDs in /boot/grub/grub.cfg for VM builds rather than hardcoding /dev/sda

### DIFF
--- a/config
+++ b/config
@@ -207,8 +207,8 @@
 
 # Use fixed disk identifiers for Virtual Machine builds.
 # Useful for reproducible builds.
-# Default: 'no'
-# FIXED_DISK_IDENTIFIERS='yes'
+# Default: 'yes'
+# FIXED_DISK_IDENTIFIERS='no'
 
 # Disk identifier when using FIXED_DISK_IDENTIFIERS='yes'.
 # Default: '26ada0c0-1165-4098-884d-aafd2220c2c6'

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -40,7 +40,7 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$TUNE2FS" ] || TUNE2FS='tune2fs -c0 -i0'
 [ -n "$UPGRADE_SYSTEM" ] || UPGRADE_SYSTEM='yes'
 [ -n "$VMSIZE" ] || VMSIZE="2G"
-[ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
+[ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="yes"
 [ -n "$DISK_IDENTIFIER" ] || DISK_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
 
 # inside the chroot system locales might not be available, so use minimum:
@@ -1091,8 +1091,12 @@ finalize_vm() {
 
   einfo "Adjusting grub.cfg for successful boot sequence."
   # ugly but needed to boot grub acordingly
-  sed -i "s;set root=.*;set root='(hd0,msdos1)';" "${MNTPOINT}"/boot/grub/grub.cfg
-  sed -i "s;root=[^ ]\+;root=/dev/sda1;" "${MNTPOINT}"/boot/grub/grub.cfg
+  if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ]; then
+     sed -i "s;root=[^ ]\+;root=UUID=$DISK_IDENTIFIER;" /boot/grub/grub.cfg
+  else
+     sed -i "s;set root=.*;set root='(hd0,msdos1)';" "${MNTPOINT}"/boot/grub/grub.cfg
+     sed -i "s;root=[^ ]\+;root=/dev/sda1;" "${MNTPOINT}"/boot/grub/grub.cfg
+  fi
 
   umount "${MNTPOINT}"
   kpartx -d "${ORIG_TARGET}" >/dev/null


### PR DESCRIPTION
This allows booting the image in KVM as either sda or vda without requiring any manual changes in /boot/grub/grub.cfg.

Use `FIXED_DISK_IDENTIFIERS="yes"` for VM builds by default.

This branch is based on my configurable_disk_identifier branch (#28), so please review and merge that one first so this one becomes mergeable.

Please review and merge.
