### PR TITLE
better error handler

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Filename:      /etc/debootstrap/chroot-script
 # Purpose:       script executed in chroot when installing Debian via grml-debootstrap
 # Authors:       grml-team (grml.org), (c) Michael Prokop <mika@grml.org>
@@ -8,6 +8,8 @@
 # GRML_CHROOT_SCRIPT_MARKER - do not remove this line unless you want to keep
 # this script as /bin/chroot-script on your new installed system
 ################################################################################
+
+trap "error_handler" ERR
 
 . /etc/debootstrap/config    || exit 1
 . /etc/debootstrap/variables || exit 1
@@ -41,6 +43,7 @@ fi
 
 # helper functions {{{
 stage() {
+  trap "error_handler" ERR
   if [ -n "$2" ] ; then
      echo "$2" > "$STAGES/$1"
      return 0
@@ -53,6 +56,7 @@ stage() {
 }
 
 askpass() {
+  trap "error_handler" ERR
   # read -s emulation for dash. result is in $resp.
   set -o noglob
   [ -t 0 ] && stty -echo
@@ -64,6 +68,7 @@ askpass() {
 
 # define chroot mirror {{{
 chrootmirror() {
+  trap "error_handler" ERR
   if [ -n "$KEEP_SRC_LIST" ] ; then
     echo "KEEP_SRC_LIST has been set, skipping chrootmirror stage."
     return
@@ -99,6 +104,7 @@ chrootmirror() {
 
 # remove local chroot mirror {{{
 remove_chrootmirror() {
+  trap "error_handler" ERR
   if [ -n "$KEEP_SRC_LIST" ] ; then
     echo "KEEP_SRC_LIST has been set, skipping remove_chrootmirror stage."
     return
@@ -122,6 +128,7 @@ remove_chrootmirror() {
 
 # set up grml repository {{{
 grmlrepos() {
+  trap "error_handler" ERR
   if [ -n "$GRMLREPOS" ] ; then
      # user might have provided their own apt sources.list
      if ! grep -q grml /etc/apt/sources.list.d/grml.list 2>/dev/null ; then
@@ -167,12 +174,14 @@ EOF
 
 # check available backports release version {{{
 checkbackports() {
+  trap "error_handler" ERR
   wget -q -O/dev/null http://backports.debian.org/debian-backports/dists/${1}-backports/Release
 }
 # }}}
 
 # feature to provide Debian backports repos {{{
 backportrepos() {
+    trap "error_handler" ERR
     if [ -n "$BACKPORTREPOS" ] ; then
         if ! checkbackports $RELEASE ; then
             echo "Backports for ${RELEASE} are not available." >&2
@@ -193,6 +202,7 @@ EOF
 
 # set up kernel-img.conf {{{
 kernelimg_conf() {
+  trap "error_handler" ERR
   if ! [ -r /etc/kernel-img.conf ] ; then
      echo "Setting up /etc/kernel-img.conf"
      cat > /etc/kernel-img.conf << EOF
@@ -207,6 +217,7 @@ EOF
 
 # make sure services do not start up {{{
 install_policy_rcd() {
+  trap "error_handler" ERR
   if ! [ -r /usr/sbin/policy-rc.d ] ; then
      export POLICYRCD=1
      cat > /usr/sbin/policy-rc.d << EOF
@@ -220,6 +231,7 @@ EOF
 
 # make sure we have an up2date system {{{
 upgrade_system() {
+  trap "error_handler" ERR
   if [ "$UPGRADE_SYSTEM" = "yes" ] ; then
     echo "Running update + upgrade"
     $APTUPDATE
@@ -232,6 +244,7 @@ upgrade_system() {
 # }}}
 # remove now useless apt cache {{{
 remove_apt_cache() {
+  trap "error_handler" ERR
   if [ "$RM_APTCACHE" = 'yes' ] ; then
     echo "Cleaning apt cache."
     apt-get clean $DPKG_OPTIONS
@@ -243,6 +256,7 @@ remove_apt_cache() {
 
 # install additional packages {{{
 packages() {
+  trap "error_handler" ERR
   # Pre-seed the debconf database with answers. Each question will be marked
   # as seen to prevent debconf from asking the question interactively.
   [ -f /etc/debootstrap/debconf-selections ] && {
@@ -264,6 +278,7 @@ packages() {
 
 # install extra packages {{{
 extrapackages() {
+    trap "error_handler" ERR
     if [ "$EXTRAPACKAGES" = 'yes' ] ; then
         PACKAGELIST=$(find /etc/debootstrap/extrapackages -type f -name '*.deb')
         if [ -n "$PACKAGELIST" ]; then
@@ -277,6 +292,7 @@ extrapackages() {
 
 # check if the specified Debian package exists
 package_exists() {
+  trap "error_handler" ERR
   output=$(apt-cache show "$1" 2>/dev/null)
   [ -n "$output" ]
   return $?
@@ -285,6 +301,7 @@ package_exists() {
 
 # determine the kernel version postfix
 get_kernel_version() {
+  trap "error_handler" ERR
   # do not override $KERNEL if set via config file
   if [ -n "$KERNEL" ] ; then
     echo "$KERNEL"
@@ -311,6 +328,7 @@ get_kernel_version() {
 
 # install kernel packages {{{
 kernel() {
+  trap "error_handler" ERR
   if [ -n "$NOKERNEL" ] ; then
     echo "Skipping installation of kernel packages as requested via --nokernel"
     return 0
@@ -330,6 +348,7 @@ kernel() {
 
 # reconfigure packages {{{
 reconfigure() {
+  trap "error_handler" ERR
   if [ -n "$RECONFIGURE" ] ; then
      for package in $RECONFIGURE ; do
          if dpkg --list $package >/dev/null 2>&1 | grep -q '^ii' ; then
@@ -344,6 +363,7 @@ reconfigure() {
 # set password of user root {{{
 passwords()
 {
+  trap "error_handler" ERR
   if [ -n "$NOPASSWORD" ] ; then
     echo "Skip setting root password as requested."
     return 0
@@ -391,6 +411,7 @@ passwords()
 
 # set up /etc/hosts {{{
 hosts() {
+  trap "error_handler" ERR
   if [ -f /etc/hosts ] ; then
      sed -i "s#127.0.0.1 .*#127.0.0.1       localhost  $HOSTNAME#" /etc/hosts
      [ -n "$HOSTNAME" ] && sed -i "s/grml/$HOSTNAME/g" /etc/hosts
@@ -416,6 +437,7 @@ EOF
 
 # set default locales {{{
 default_locales() {
+  trap "error_handler" ERR
   if [ -n "$DEFAULT_LOCALES" ] ; then
     if ! [ -x /usr/sbin/update-locale ] ; then
       echo "Warning: update-locale executable not available (no locales package installed?)"
@@ -430,6 +452,7 @@ default_locales() {
 
 # adjust timezone {{{
 timezone() {
+  trap "error_handler" ERR
   if [ -n "$TIMEZONE" ] ; then
      echo "Adjusting /etc/localtime"
      ln -sf /usr/share/zoneinfo/$TIMEZONE /etc/localtime
@@ -439,6 +462,7 @@ timezone() {
 
 # helper function for fstab() {{{
 createfstab(){
+     trap "error_handler" ERR
      echo "Setting up /etc/fstab"
 if [ -n "$TARGET_UUID" ] ; then
    echo "/dev/disk/by-uuid/${TARGET_UUID} /  auto    defaults,errors=remount-ro 0   1" > /etc/fstab
@@ -462,6 +486,7 @@ EOF
 
 # generate /etc/fstab {{{
 fstab() {
+  trap "error_handler" ERR
   # set up /etc/fstab if file is not present (cdebootstrap)
   if [ ! -f /etc/fstab  ] ; then
      createfstab
@@ -476,6 +501,7 @@ fstab() {
 
 # set up hostname {{{
 hostname() {
+  trap "error_handler" ERR
   if [ -n "$HOSTNAME" ] ; then
      echo "Setting hostname to ${HOSTNAME}."
      echo "$HOSTNAME" > /etc/hostname
@@ -495,6 +521,7 @@ hostname() {
 
 # generate initrd/initramfs {{{
 initrd() {
+  trap "error_handler" ERR
   # assume the first available kernel as our main kernel
   KERNELIMG=$(ls -1 /boot/vmlinuz-* 2>/dev/null | head -1)
   if [ -z "$KERNELIMG" ] ; then
@@ -514,6 +541,7 @@ initrd() {
 
 # grub configuration/installation {{{
 grub_install() {
+  trap "error_handler" ERR
 
   if [ -z "$GRUB" ] ; then
     echo "Notice: \$GRUB not defined, will not install grub inside chroot at this stage."
@@ -559,6 +587,7 @@ grub_install() {
 
 # execute all scripts present in /etc/debootstrap/chroot-scripts/ {{{
 custom_scripts() {
+  trap "error_handler" ERR
   [ -d /etc/debootstrap/chroot-scripts/ ] || return 0
 
   for script in /etc/debootstrap/chroot-scripts/* ; do
@@ -570,6 +599,7 @@ custom_scripts() {
 
 # make sure we don't have any running processes left {{{
 services() {
+  trap "error_handler" ERR
   for service in ssh mdadm mdadm-raid ; do
     if [ -x /etc/init.d/"$service" ] ; then
        /etc/init.d/"$service" stop || true
@@ -580,6 +610,7 @@ services() {
 
 # unmount /proc and make sure nothing is left {{{
 finalize() {
+  trap "error_handler" ERR
   # make sure we don't leave any sensible data
   rm -f /etc/debootstrap/variables
 
@@ -591,6 +622,7 @@ finalize() {
 
 # signal handler {{{
 signal_handler() {
+  trap "error_handler" ERR
   finalize
   [ -n "$1" ] && EXIT="$1" || EXIT="1"
   exit "$EXIT"

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -6,6 +6,34 @@
 # License:       This file is licensed under the GPL v2+
 ################################################################################
 
+# error_handler {{{
+[ -n "$REPORT_TRAP_ERR" ] || REPORT_TRAP_ERR='no'
+[ -n "$FAIL_TRAP_ERR" ] || FAIL_TRAP_ERR='no'
+
+error_handler() {
+   last_exit_code="$?"
+   last_bash_command="$BASH_COMMAND"
+   if [ "$REPORT_TRAP_ERR" = "yes" ]; then
+      echo "Unexpected non-zero exist code $last_exit_code in $BASH_SOURCE detected!
+last bash command: $last_bash_command"
+   fi
+   if [ ! "$FAIL_TRAP_ERR" = "yes" ]; then
+      return
+   fi
+   command -v bailout >/dev/null 2>&1
+   if [ "$?" = "0" ]; then
+      bailout 1
+   else
+      echo 'FAIL_TRAP_ERR is set to "yes", exit 1.'
+      exit 1
+   fi
+}
+
+trap "error_handler" ERR
+
+export -f "error_handler"
+# }}}
+
 # variables {{{
 PN="$(basename $0)"
 VERSION="$(dpkg-query --show --showformat='${Version}' "$PN")"
@@ -53,6 +81,8 @@ INTERACTIVE=''
 
 # help text {{{
 usage() {
+  trap "error_handler" ERR
+
   echo "$PN - wrapper around debootstrap for installing Debian
 
 Usage: $PN [options]
@@ -142,11 +172,13 @@ HILITE='[36;01m'
 BRACKET='[34;01m'
 
 einfo() {
+  trap "error_handler" ERR
   einfon "$1\n"
   return 0
 }
 
 einfon() {
+  trap "error_handler" ERR
   [ "${RC_ENDCOL}" != "yes" ] && [ "${LAST_E_CMD}" = "ebegin" ] && echo
   printf " ${GOOD}*${NORMAL} $*"
   LAST_E_CMD=einfon
@@ -154,6 +186,7 @@ einfon() {
 }
 
 eerror() {
+  trap "error_handler" ERR
   [ "${RC_ENDCOL}" != "yes" ] && [ "${LAST_E_CMD}" = "ebegin" ] && echo
   printf " ${BAD}*${NORMAL} $*\n" >&2
   LAST_E_CMD=eerror
@@ -161,6 +194,7 @@ eerror() {
 }
 
 eend() {
+  trap "error_handler" ERR
   local retval="${1:-0}"
   shift
   if [ $retval -gt 0 ]; then
@@ -170,12 +204,14 @@ eend() {
 }
 
 check4root(){
+  trap "error_handler" ERR
   if [ "$(id -u 2>/dev/null)" != 0 ] ; then
     echo 1>&2 "Error: please run this script with uid 0 (root)." ; return 1
   fi
 }
 
 check4progs(){
+  trap "error_handler" ERR
   local RC=''
   for arg in $* ; do
     which $arg >/dev/null 2>&1 || RC="$arg"
@@ -189,6 +225,7 @@ check4progs(){
 
 # helper functions {{{
 cleanup() {
+  trap "error_handler" ERR
   if [ -n "$CHROOT_VARIABLES" ] ; then
     einfo "Removing ${CHROOT_VARIABLES}" ; rm "$CHROOT_VARIABLES" ; eend $?
   fi
@@ -252,6 +289,7 @@ cleanup() {
 
 # we want to exit smoothly and clean:
 bailout(){
+  trap "error_handler" ERR
 
   cleanup
 
@@ -264,6 +302,8 @@ trap bailout HUP INT QUIT TERM
 
 # we want to execute all the functions only once, simple check for it:
 stage() {
+  trap "error_handler" ERR
+
   if [ -n "$2" ] ; then
      echo "$2" > "${STAGES}/${1}"
      return 0
@@ -409,6 +449,7 @@ fi
 # welcome screen {{{
 welcome_dialog()
 {
+   trap "error_handler" ERR
    dialog --title "$PN" --yesno "Welcome to the interactive configuration of ${PN}.
 Do you want to continue installing Debian using this frontend?" 0 0 || bailout 0
 }
@@ -417,6 +458,7 @@ Do you want to continue installing Debian using this frontend?" 0 0 || bailout 0
 # ask for target {{{
 prompt_for_target()
 {
+  trap "error_handler" ERR
   AVAILABLE_PARTITIONS=$(LANG=C fdisk -l 2>/dev/null | \
                sed 's/*//' | \
                grep -v 'Extended$' | \
@@ -444,6 +486,7 @@ prompt_for_target()
 # ask for bootmanager {{{
 prompt_for_bootmanager()
 {
+  trap "error_handler" ERR
   ADDITIONAL_PARAMS=""
 
   if echo "$TARGET" | grep -q "/dev/md" ; then
@@ -511,6 +554,7 @@ prompt_for_bootmanager()
 # ask for Debian release {{{
 prompt_for_release()
 {
+  trap "error_handler" ERR
   [ -n "$RELEASE" ] && DEFAULT_RELEASE="$RELEASE" || DEFAULT_RELEASE='wheezy'
   RELEASE="$(dialog --stdout --title "${PN}" --default-item $DEFAULT_RELEASE --menu \
             "Please enter the Debian release you would like to use for installation:" \
@@ -526,6 +570,7 @@ prompt_for_release()
 # ask for hostname {{{
 prompt_for_hostname()
 {
+  trap "error_handler" ERR
   HOSTNAME="$(dialog --stdout --title "${PN}" --inputbox \
             "Please enter the hostname you would like to use for installation:" \
             0 0 $HOSTNAME)"
@@ -536,6 +581,7 @@ prompt_for_hostname()
 # ask for password {{{
 prompt_for_password()
 {
+  trap "error_handler" ERR
   if [ "$_opt_nopassword" ] ; then
     einfo "Skip asking for root password as requested."
     return 0
@@ -564,6 +610,7 @@ prompt_for_password()
 # ask for Debian mirror {{{
 prompt_for_mirror()
 {
+  trap "error_handler" ERR
   [ -n "$ISO" ] && DEFAULT_MIRROR='local' || DEFAULT_MIRROR='net'
 
   CHOOSE_MIRROR=$(dialog --stdout --title "$PN" --default-item $DEFAULT_MIRROR \
@@ -592,6 +639,8 @@ prompt_for_mirror()
 # software raid setup {{{
 config_swraid_setup()
 {
+trap "error_handler" ERR
+
 TMPFILE=$(mktemp)
 
 # Currently we support only raid1:
@@ -665,6 +714,7 @@ fi
 
 prompt_for_swraid()
 {
+trap "error_handler" ERR
 if dialog --stdout --title "$PN" \
           --defaultno --yesno "Do you want to configure Software RAID?
 
@@ -677,6 +727,7 @@ fi
 # user should recheck his configuration {{{
 # support full automatic installation:
 checkforrun() {
+   trap "error_handler" ERR
    dialog --timeout 10 --title "$PN" \
           --yesno "Do you want to stop at this stage?
 
@@ -691,6 +742,7 @@ Do you want to stop now?" 0 0 2>/dev/null
 # make sure the user is aware of the used configuration {{{
 checkconfiguration()
 {
+trap "error_handler" ERR
 if [ -n "$AUTOINSTALL" ] ; then
    if checkforrun ; then
       eerror "Exiting as requested" ; eend 0
@@ -776,6 +828,8 @@ fi
 # interactive mode {{{
 interactive_mode()
 {
+  trap "error_handler" ERR
+
   check4progs dialog || bailout 1
 
   welcome_dialog
@@ -855,6 +909,7 @@ PARTITION=''
 DIRECTORY=''
 
 set_target_directory(){
+    trap "error_handler" ERR
     # assume we are installing into a directory, don't run mkfs and grub related stuff therefore
     DIRECTORY=1
     MNTPOINT="$TARGET"
@@ -896,6 +951,7 @@ fi
 
 # create filesystem {{{
 mkfs() {
+  trap "error_handler" ERR
   if [ -n "$DIRECTORY" ] ; then
      einfo "Running grml-debootstrap on a directory, skipping mkfs stage."
   else
@@ -943,6 +999,7 @@ mkfs() {
 
 # modify filesystem settings {{{
 tunefs() {
+  trap "error_handler" ERR
   if [ -n "$TUNE2FS" ] && echo "$MKFS" | grep -q "mkfs.ext" ; then
      einfo "Disabling automatic filesystem check on $TARGET via tune2fs"
      $TUNE2FS $TARGET
@@ -953,6 +1010,7 @@ tunefs() {
 
 # mount the new partition or if it's a directory do nothing at all {{{
 mount_target() {
+  trap "error_handler" ERR
   if [ -n "$DIRECTORY" ] ; then
      einfo "Running grml-debootstrap on a directory, nothing to mount."
   else
@@ -979,6 +1037,7 @@ mount_target() {
 
 # prepare VM image for usage with debootstrap {{{
 prepare_vm() {
+  trap "error_handler" ERR
   if [ -z "$VIRTUAL" ] ; then
      return 0 # be quiet by intention
   fi
@@ -1053,6 +1112,7 @@ prepare_vm() {
 
 # make VM image bootable and unmount it {{{
 finalize_vm() {
+  trap "error_handler" ERR
   if [ -z "${VIRTUAL}" ] ; then
      return 0
   fi
@@ -1100,6 +1160,7 @@ finalize_vm() {
 
 # install main chroot {{{
 debootstrap_system() {
+  trap "error_handler" ERR
   if [ "$_opt_nodebootstrap" ]; then
      einfo "Skipping debootstrap as requested."
      return
@@ -1139,6 +1200,7 @@ debootstrap_system() {
 
 # prepare chroot via chroot-script {{{
 preparechroot() {
+  trap "error_handler" ERR
   einfo "Preparing chroot system"
 
   # provide variables to chroot system
@@ -1186,6 +1248,8 @@ preparechroot() {
   [ -n "$TIMEZONE" ]            && echo "TIMEZONE=\"$TIMEZONE\""                       >> $CHROOT_VARIABLES
   [ -n "$TUNE2FS" ]             && echo "TUNE2FS=\"$TUNE2FS\""                         >> $CHROOT_VARIABLES
   [ -n "$VMSIZE" ]              && echo "VMSIZE=\"$VMSIZE\""                           >> $CHROOT_VARIABLES
+  [ -n "$REPORT_TRAP_ERR" ]     && echo "REPORT_TRAP_ERR=\"$REPORT_TRAP_ERR\""         >> $CHROOT_VARIABLES
+  [ -n "$FAIL_TRAP_ERR" ]       && echo "FAIL_TRAP_ERR=\"$FAIL_TRAP_ERR\""             >> $CHROOT_VARIABLES
 
   cp $VERBOSE $CONFFILES/chroot-script $MNTPOINT/bin/chroot-script
   chmod 755 $MNTPOINT/bin/chroot-script
@@ -1292,6 +1356,7 @@ iface eth0 inet dhcp
 
 # execute all scripts in /etc/debootstrap/pre-scripts/ {{{
 execute_pre_scripts() {
+   trap "error_handler" ERR
    # make sure we have $MNTPOINT available for our scripts
    export MNTPOINT
    if [ -d "$_opt_pre_scripts" ] || [ "$PRE_SCRIPTS" = 'yes' ] ; then
@@ -1308,6 +1373,7 @@ execute_pre_scripts() {
 
 # execute all scripts in /etc/debootstrap/scripts/ {{{
 execute_scripts() {
+   trap "error_handler" ERR
    # make sure we have $MNTPOINT available for our scripts
    export MNTPOINT
    if [ -d "$_opt_scripts" ] || [ "$SCRIPTS" = 'yes' ] ; then
@@ -1324,6 +1390,7 @@ execute_scripts() {
 
 # execute chroot-script {{{
 chrootscript() {
+  trap "error_handler" ERR
   if ! [ -r "$MNTPOINT/bin/chroot-script" ] ; then
     mount_target
   fi
@@ -1335,7 +1402,7 @@ chrootscript() {
     einfo "Executing chroot-script now"
     mount --bind /dev "$MNTPOINT"/dev
     if [ "$DEBUG" = "true" ] ; then
-      chroot "$MNTPOINT" /bin/sh -x /bin/chroot-script ; RC=$?
+      chroot "$MNTPOINT" /bin/bash -x /bin/chroot-script ; RC=$?
     else
       chroot "$MNTPOINT" /bin/chroot-script ; RC=$?
     fi
@@ -1358,6 +1425,7 @@ chrootscript() {
 
 # unmount $MNTPOINT {{{
 umount_chroot() {
+  trap "error_handler" ERR
 
   # display installation notes:
   if [ -n "$INSTALL_NOTES" ] ; then
@@ -1384,6 +1452,7 @@ umount_chroot() {
 
 # execute filesystem check {{{
 fscktool() {
+ trap "error_handler" ERR
  if [ -n "$VIRTUAL" ] ; then
    einfo "Skipping filesystem check because we deploy a virtual machine."
    return 0


### PR DESCRIPTION
Implements #22 (better error handling).

I couldn't hesitate creating an implementation draft. Curious how you like this.

```
export REPORT_TRAP_ERR='yes'
```

Reports unexpected non-zero exit codes.

```
export FAIL_TRAP_ERR='yes'
```

Fails on unexpected non-zero exit codes.

I created a VM image using both options. Congratulations. So far no unexpected non-zero exit codes. If this gets merged, I suggest to leave it disabled by default in short term and to enable `export REPORT_TRAP_ERR='yes'` as developer/tester. It will report unexpected non-zero exit codes but not annoy any further. Later when we're really sure to have all exit codes under control we can consider making `export FAIL_TRAP_ERR='yes'` the default.
