### PR TITLE
Add function set-hostname in /etc/mailname

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -489,6 +489,10 @@ hostname() {
         sed -i "s/^inet_interfaces = .*/inet_interfaces = loopback-only/" /etc/postfix/main.cf
         grep -q inet_interfaces /etc/postfix/main.cf || echo 'inet_interfaces = loopback-only' >> /etc/postfix/main.cf
      fi
+     if [ -r /etc/mailname ] ; then
+       # adjust hostname in /etc/mailname
+       sed -i "s/grml/$HOSTNAME/g" /etc/mailname
+     fi
   fi
 }
 # }}}


### PR DESCRIPTION
Bugfix for Issue 1315 (http://bts.grml.org/grml/issue1315)
- Add function set-hostname in file /etc/mailname
