### PR TITLE
Bugfix issue-1315: Add set process for /etc/mailname

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -489,6 +489,20 @@ hostname() {
         sed -i "s/^inet_interfaces = .*/inet_interfaces = loopback-only/" /etc/postfix/main.cf
         grep -q inet_interfaces /etc/postfix/main.cf || echo 'inet_interfaces = loopback-only' >> /etc/postfix/main.cf
      fi
+     if [ -r /etc/mailname ] ; then
+        # adjust /etc/mailname
+	local etc_mail_domain=$(/bin/dnsdomainname 2>/dev/null || echo localdomain)
+	case "$HOSTNAME" in
+	  *.*)
+		  local mailname="$HOSTNAME"
+	    ;;
+          *)
+		  local mailname="${HOSTNAME}.${etc_mail_domain}"
+            ;;
+	esac
+	echo "Setting mailname to ${mailname}"
+	echo "$mailname" > /etc/mailname
+     fi
   fi
 }
 # }}}


### PR DESCRIPTION
It's a bugfix for issue-1315 (http://bts.grml.org/grml/issue1315).
I add a routine to add the mailname in /etc/mailname, if option is used like `--hostname=grmlhost`.
