### PR TITLE
better error handler version2

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Filename:      /etc/debootstrap/chroot-script
 # Purpose:       script executed in chroot when installing Debian via grml-debootstrap
 # Authors:       grml-team (grml.org), (c) Michael Prokop <mika@grml.org>
@@ -8,6 +8,14 @@
 # GRML_CHROOT_SCRIPT_MARKER - do not remove this line unless you want to keep
 # this script as /bin/chroot-script on your new installed system
 ################################################################################
+
+# error_handler {{{
+if [ "$REPORT_TRAP_ERR" = "yes" ] || [ "$FAIL_TRAP_ERR" = "yes" ]; then
+   set -E
+   set -o pipefail
+   trap "error_handler" ERR
+fi
+# }}}
 
 . /etc/debootstrap/config    || exit 1
 . /etc/debootstrap/variables || exit 1

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -6,6 +6,38 @@
 # License:       This file is licensed under the GPL v2+
 ################################################################################
 
+# error_handler {{{
+[ -n "$REPORT_TRAP_ERR" ] || REPORT_TRAP_ERR='no'
+[ -n "$FAIL_TRAP_ERR" ] || FAIL_TRAP_ERR='no'
+
+error_handler() {
+   last_exit_code="$?"
+   last_bash_command="$BASH_COMMAND"
+   if [ "$REPORT_TRAP_ERR" = "yes" ]; then
+      echo "Unexpected non-zero exit code $last_exit_code in $BASH_SOURCE at line $BASH_LINENO detected!
+last bash command: $last_bash_command"
+   fi
+   if [ ! "$FAIL_TRAP_ERR" = "yes" ]; then
+      return
+   fi
+   ## Check if "bailout" function is available.
+   ## This is not the case in chroot-script.
+   if command -v bailout >/dev/null 2>&1; then
+      bailout 1
+   else
+      echo 'FAIL_TRAP_ERR is set to "yes", exit 1.'
+      exit 1
+   fi
+}
+
+if [ "$REPORT_TRAP_ERR" = "yes" ] || [ "$FAIL_TRAP_ERR" = "yes" ]; then
+   set -E
+   set -o pipefail
+   trap "error_handler" ERR
+   export -f "error_handler"
+fi
+# }}}
+
 # variables {{{
 PN="$(basename "$0")"
 VERSION="$(dpkg-query --show --showformat='${Version}' "$PN")"
@@ -1351,7 +1383,7 @@ chrootscript() {
     einfo "Executing chroot-script now"
     mount --bind /dev "$MNTPOINT"/dev
     if [ "$DEBUG" = "true" ] ; then
-      chroot "$MNTPOINT" /bin/sh -x /bin/chroot-script ; RC=$?
+      chroot "$MNTPOINT" /bin/bash -x /bin/chroot-script ; RC=$?
     else
       chroot "$MNTPOINT" /bin/chroot-script ; RC=$?
     fi


### PR DESCRIPTION
Implements #22 (better error handling). Hopefully addresses concerns from previous pull request "better error handler" (#31). This time it's a much less intrusive, smaller change.

Thanks for @hartwork for telling me about `set -E`.

```
export REPORT_TRAP_ERR='yes'
```

Reports unexpected non-zero exit codes.

```
export FAIL_TRAP_ERR='yes'
```

Fails on unexpected non-zero exit codes.

I created a VM image using both options. Congratulations. So far no unexpected non-zero exit codes. If this gets merged, I suggest to leave it disabled by default in short term and to enable `export REPORT_TRAP_ERR='yes'` as developer/tester. It will report unexpected non-zero exit codes but not annoy any further. Later when we're really sure to have all exit codes under control we can consider making `export FAIL_TRAP_ERR='yes'` the default.