### PR TITLE
Fixed version reported when run from Git (issue #55)

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -8,7 +8,11 @@
 
 # variables {{{
 PN="$(basename "$0")"
-VERSION="$(dpkg-query --show --showformat='${Version}' "$PN")"
+if [[ -d "$(dirname "$(which "$0")")"/.git ]]; then
+  VERSION="$(git describe | sed 's|^v||')"
+else
+  VERSION="$(dpkg-query --show --showformat='${Version}' "$PN")"
+fi
 VERSION="${VERSION:-unknown}"
 MNTPOINT="/mnt/debootstrap.$$"
 


### PR DESCRIPTION
I refrained from using
```
dpkg-parsechangelog | sed -e '/^Version: / !d' -e 's|^Version: ||'
```
eventually, to not add a runtime dependency on `dpkg-dev`.
If that dependency is fine by you, feel free to replace
```
git describe | sed 's|^v||'
```
with the former.

Best, Sebastian