### PR TITLE
Revert mistaken dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,6 @@ Depends: debian-archive-keyring,
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: dialog,
-            grub-common,
             kpartx,
             mksh,
             parted,

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -389,7 +389,7 @@ fi
 
 # make sure we have what we need {{{
 if [ -n "$VIRTUAL" ] ; then
-  check4progs grub-mkimage kpartx mksh parted qemu-img || bailout 1
+  check4progs kpartx mksh parted qemu-img || bailout 1
 fi
 # }}}
 


### PR DESCRIPTION
Previously, I overlooked that grub-mkimage is called from inside the chroot, only. Therefore it is not required on the host system.