### PR TITLE
Use official redirector address httpredir.debian.org

### DIFF
--- a/config
+++ b/config
@@ -37,7 +37,7 @@
 
 # Set mirror where packages will be downloaded from.
 # Default: use /etc/debootstrap/etc/apt/sources.list if it exists, else
-# 'http://http.debian.net/debian'
+# 'http://httpredir.debian.org/debian'
 # Usage example:
 # MIRROR='ftp://ftp.de.debian.org/debian'
 

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -58,7 +58,7 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$DEFAULT_LOCALES" ] || DEFAULT_LOCALES='en_US.UTF-8'
 [ -n "$DISK_IDENTIFIER" ] || DISK_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
 [ -n "$EXTRAPACKAGES" ] || EXTRAPACKAGES='yes'
-[ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://http.debian.net/debian'
+[ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://httpredir.debian.org/debian'
 [ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
 [ -n "$FORCE" ] || FORCE=''
 [ -n "$HOSTNAME" ] || HOSTNAME='grml'
@@ -652,7 +652,7 @@ prompt_for_mirror()
   [ $? -eq 0 ] || bailout
 
   if [ "$CHOOSE_MIRROR" = 'net' ] ; then
-     [ -n "$MIRROR" ] || MIRROR='http://http.debian.net/debian'
+     [ -n "$MIRROR" ] || MIRROR='http://httpredir.debian.org/debian'
      MIRROR="$(dialog --stdout --title "${PN}" --inputbox \
                "Please enter Debian mirror you would like to use for installing packages." \
                0 0 $MIRROR)"

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -272,7 +272,7 @@ any bootloader).
 
 Install default Debian release (jessie) on /dev/sda3 and install bootmanager
 Grub in MBR (master boot record) of /dev/sda and use /dev/sda3 as system partition.
-Use specified mirror instead of the default (http://http.debian.net/debian) one.
+Use specified mirror instead of the default (http://httpredir.debian.org/debian) one.
 
   mount /dev/sda1 /mnt/sda1
   grml-debootstrap --vmfile --vmsize 3G --target /mnt/sda1/qemu.img
@@ -359,7 +359,7 @@ releases: lenny, squeeze, wheezy, jessie, stretch and sid. Usage example: releas
   mirror=...
 
 Specify mirror which should be used for apt-get/aptitude instead
-of the default one (http://http.debian.net/debian).
+of the default one (http://httpredir.debian.org/debian).
 Usage example: mirror=ftp://ftp.tugraz.at/mirror/debian
 
   password=...
@@ -396,7 +396,7 @@ anymore unless you really know what you are doing. Choose Debian 8.0 (jessie) or
 something newer instead.
 
 Notice that you need to specify a mirror providing the lenny release, the
-default (http://http.debian.net/debian) doesn't provide it any longer nowadays.
+default (http://httpredir.debian.org/debian) doesn't provide it any longer nowadays.
 Set the mirror to e.g. http://archive.debian.org/debian/ if you don't have
 your own lenny mirror.
 


### PR DESCRIPTION
The address [`http.debian.net`](http://http.debian.net) is officially replaced by
[`httpredir.debian.org`](http://httpredir.debian.org).

Use the following command to update all places.

	git grep -l 'http.debian.net/debian' | xargs sed -i 's,http.debian.net/debian,httpredir.debian.org/debian,g'