### PR TITLE
Export TARGET_HOSTNAME before running post-scripts

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1530,8 +1530,9 @@ execute_pre_scripts() {
 
 # execute all scripts in /etc/debootstrap/post-scripts/ {{{
 execute_post_scripts() {
-  # make sure we have $MNTPOINT available for our scripts
+  # make sure we have $MNTPOINT and HOSTNAME available for our scripts
   export MNTPOINT
+  export TARGET_HOSTNAME=$HOSTNAME
 
   if [ -d "$_opt_scripts" ] || [ "$SCRIPTS" = 'yes' ] ; then
     # legacy support for /etc/debootstrap/scripts/


### PR DESCRIPTION
Export $HOSTNAME in $TARGET_HOSTNAME so one is able to do customize things based upon the hostname of the installed machine (eg. to populate /e/n/interfaces by doing a external database lookup).