### PR TITLE
Update /dev and /dev/pts mount from --bind to proper fs type

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1241,8 +1241,8 @@ finalize_vm() {
 
   mount -t proc none "${MNTPOINT}"/proc
   mount -t sysfs none "${MNTPOINT}"/sys
-  mount --bind /dev "${MNTPOINT}"/dev
-  mount --bind /dev/pts "${MNTPOINT}"/dev/pts
+  mount -t devtmpfs udev "${MNTPOINT}"/dev
+  mount -t devpts devpts "${MNTPOINT}"/dev/pts
 
 # Has chroot-script installed GRUB to MBR using grub-install (successfully), already?
 # chroot-script skips installation for unset ${GRUB}
@@ -1575,8 +1575,8 @@ chrootscript() {
     eend 1
   else
     einfo "Executing chroot-script now"
-    mount --bind /dev "$MNTPOINT"/dev
-    mount --bind /dev/pts "$MNTPOINT"/dev/pts
+    mount -t devtmpfs udev "${MNTPOINT}"/dev
+    mount -t devpts devpts "${MNTPOINT}"/dev/pts
     if [ "$DEBUG" = "true" ] ; then
       chroot "$MNTPOINT" /bin/bash -x /bin/chroot-script ; RC=$?
     else


### PR DESCRIPTION
We are using grml-debootstrap to create various virtual machine in parallel. Our build system started failing after updating to debian stretch, where grml-debootstrap version is 0.78.

When you run multiple grml-debootstrap in parallel, specifying a target in /dev, the bind mount of /dev and /dev/pts makes the successive umount and delete of the temporary mount folder failing.

I think this is caused by how --bind works with recent versions of systemd and udev.

Using proper filesystem definitions in the mount part and removing the bind mount completely solves our problem.

Is this something you think can be pushed upstream or could break compatibility on other systems which are not Debian based?