### PR TITLE
Initial VM test builds on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ env:
   - TRAVIS_DEBIAN_DISTRIBUTION=unstable TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER=true
 
 script:
-  - docker run koalaman/shellcheck:stable --version
-  - docker run -v "$(pwd)":/code koalaman/shellcheck:stable -e SC2181 /code/chroot-script /code/grml-debootstrap
-  - wget -O- http://travis.debian.net/script.sh | sh -
+  - ./travis/execute.sh
 
 matrix:
   fast_finish: true

--- a/travis/build-vm.sh
+++ b/travis/build-vm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+TARGET="${TARGET:-/code/qemu.img}"
+RELEASE="${RELEASE:-stretch}"
+
+cd "$(dirname "$TARGET")"
+apt update
+apt -y install ./grml-debootstrap*.deb
+
+grml-debootstrap \
+  --force \
+  --vmfile \
+  --vmsize 3G \
+  --target "$TARGET" \
+  --bootappend "console=ttyS0,115200 console=tty0 vga=791" \
+  --password grml \
+  --release  "$RELEASE" \
+  --hostname "$RELEASE" \
+  # EOF

--- a/travis/execute.sh
+++ b/travis/execute.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+RELEASE="${RELEASE:-stretch}"
+export RELEASE
+
+# run shellcheck tests
+docker run koalaman/shellcheck:stable --version
+docker run -v "$(pwd)":/code koalaman/shellcheck:stable -e SC2181 /code/chroot-script /code/grml-debootstrap
+
+# build Debian package
+wget -O- https://travis.debian.net/script.sh | sh -
+
+if ! [ "${TRAVIS_DEBIAN_DISTRIBUTION:-}" = "unstable" ] ; then
+  echo "TRAVIS_DEBIAN_DISTRIBUTION is $TRAVIS_DEBIAN_DISTRIBUTION and not unstable, skipping VM build tests."
+  exit 0
+fi
+
+# copy only the binary from the TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER=true build
+cp ../grml-debootstrap_*travis*deb .
+
+# we need to run in privileged mode to be able to use loop devices
+docker run --privileged -v "$(pwd)":/code --rm -i -t debian:stretch /code/travis/build-vm.sh
+
+[ -x ./goss ] || curl -fsSL https://goss.rocks/install | GOSS_DST="$(pwd)" sh
+
+sudo apt-get update
+sudo apt-get -y install qemu-system-x86
+
+# sudo timeout --preserve-status --foreground 120 qemu-system-x86_64 -hda qemu.img -serial stdio -display none | tee -a qemu.log
+sudo qemu-system-x86_64 -hda qemu.img -serial stdio -display none | tee -a qemu.log &
+
+timeout=120
+success=0
+while [ "$timeout" -gt 0 ]; do
+  ((timeout--))
+  if ./goss --gossfile ./travis/goss.yaml validate --format nagios ; then
+    success=1
+    sleep 1
+    break
+  else
+    echo "Tests didn't pass YET, will retry again [$timeout retries left]"
+    sleep 1
+  fi
+done
+
+if [ "$success" = "1" ] ; then
+  echo "All tests passed! (◕‿◕)"
+else
+  echo "Reached timeout after $timeout seconds with failing tests. ¯\(º o)/¯ ☂" >&2
+  echo "Latest test run results:"
+  ./goss --gossfile ./travis/goss.yaml validate
+  exit 1
+fi

--- a/travis/goss.yaml
+++ b/travis/goss.yaml
@@ -1,0 +1,5 @@
+command:
+  grep -qe "Debian GNU/Linux .* {{ .Env.RELEASE }} ttyS0" qemu.log:
+    exit-status: 0
+  grep -qe "{{ .Env.RELEASE }} login:" qemu.log:
+    exit-status: 0


### PR DESCRIPTION
We're starting a Docker container with Debian/stretch, installing
the Debian package build result (generated via travis.debian.net)
of grml-debootstrap inside it. Then execute grml-debootstrap,
installing to a VM file. Finally boot the generated VM file via
qemu.

We use stdio of qemu's serial console to check for the boot prompt
of the installed Debian system, using goss for running the actual
checks.

See https://travis-ci.org/mika/grml-debootstrap/jobs/407635286 for the actual test run on TravisCI.
