### PR TITLE
Properly exit if GRUB installation fails

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -616,19 +616,31 @@ grub_install() {
      for device in $SELECTED_PARTITIONS ; do
         GRUB="${device%%[0-9]}"
         echo "Installing grub on ${GRUB}:"
-        grub-install --no-floppy "$GRUB"
+        if ! grub-install --no-floppy "$GRUB" ; then
+          echo "Error: failed to execute 'grub-install --no-floppy $GRUB'." >&2
+          exit 1
+        fi
+
      done
      rm -f /boot/grub/device.map
   else
      echo "Installing grub on ${GRUB}:"
      case "$RELEASE" in
        lenny|squeeze|wheezy)
-         grub-install --no-floppy "$(readlink -f "${GRUB}")"
+         local grub_dev
+         grub_dev="$(readlink -f "${GRUB}")"
+         if ! grub-install --no-floppy "${grub_dev}" ; then
+           echo "Error: failed to execute 'grub-install --no-floppy ${grub_dev}'." >&2
+           exit 1
+         fi
          rm -f /boot/grub/device.map
          ;;
        *)
          echo "(hd0) ${GRUB}" > /boot/grub/device.map
-         grub-install "(hd0)"
+         if ! grub-install "(hd0)" ; then
+           echo "Error: failed to execute 'grub-install (hd0)'." >&2
+           exit 1
+         fi
          rm /boot/grub/device.map
          ;;
      esac


### PR DESCRIPTION
For example when partition table is GPT but grub installation
expects a MS-DOS partition table, then grub-install fails
but grml-debootstrap ignored this. Since the system isn't bootable
then this might go unnoticed, so properly fail as soon as grub-install
returns with exit code != 0.