### PR TITLE
Packaging improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1347,4 +1347,3 @@ grml-debootstrap (0.1) unstable; urgency=low
   * Initial release.
 
  -- Michael Prokop <mika@grml.org>  Fri,  3 Nov 2006 01:10:52 +0100
-

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends-Indep:
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://grml.org/grml-debootstrap/
-Vcs-git: git://git.grml.org/grml-debootstrap.git
+Vcs-Git: git://git.grml.org/grml-debootstrap.git
 Vcs-Browser: https://git.grml.org/?p=grml-debootstrap.git
 
 Package: grml-debootstrap

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends-Indep:
  shunit2,
  xsltproc,
 Standards-Version: 4.5.0
+Rules-Requires-Root: no
 Homepage: https://grml.org/grml-debootstrap/
 Vcs-git: git://git.grml.org/grml-debootstrap.git
 Vcs-Browser: https://git.grml.org/?p=grml-debootstrap.git

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Uploaders:
  Chris Hofstaedtler <zeha@debian.org>,
  Ulrich Dangel <mru@spamt.net>,
 Build-Depends:
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
 Build-Depends-Indep:
  asciidoc,
  docbook-xsl,

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Grml Team <team@grml.org>
 Uploaders:
  Michael Prokop <mika@debian.org>,
  Alexander Wirt <formorer@debian.org>,
- Christian Hofstaedtler <zeha@debian.org>,
+ Chris Hofstaedtler <zeha@debian.org>,
  Ulrich Dangel <mru@spamt.net>,
 Build-Depends:
  debhelper-compat (= 12),

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,5 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1


### PR DESCRIPTION
Fixes these lintian issues:

* P: grml-debootstrap source: cute-field debian/control@source Vcs-git vs Vcs-Git
* P: grml-debootstrap source: package-uses-old-debhelper-compat-version 12
* P: grml-debootstrap source: silent-on-rules-requiring-root
* P: grml-debootstrap source: trailing-whitespace debian/changelog (line 1350)

Plus shortens my name.

No binary changes pop up in a diffoscope run.
