### PR TITLE
Properly handle KEEP_SRC_LIST option when set to 'no'

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -75,8 +75,8 @@ askpass() {
 
 # define chroot mirror {{{
 chrootmirror() {
-  if [ -n "$KEEP_SRC_LIST" ] ; then
-    echo "KEEP_SRC_LIST has been set, skipping chrootmirror stage."
+  if [ "$KEEP_SRC_LIST" = "yes" ] ; then
+    echo "KEEP_SRC_LIST has been enabled, skipping chrootmirror stage."
     return
   fi
 
@@ -129,8 +129,8 @@ chrootmirror() {
 
 # remove local chroot mirror {{{
 remove_chrootmirror() {
-  if [ -n "$KEEP_SRC_LIST" ] ; then
-    echo "KEEP_SRC_LIST has been set, skipping remove_chrootmirror stage."
+  if [ "$KEEP_SRC_LIST" = "yes" ] ; then
+    echo "KEEP_SRC_LIST has been enabled, skipping remove_chrootmirror stage."
     return
   fi
 


### PR DESCRIPTION
If the configuration includes KEEP_SRC_LIST='no',
then it behaves as if it's set to 'yes', as we were
just checking whether it's set or not.

Closes: grml/grml-debootstrap#160