### PR TITLE
Do not enable escape characters on dumb terminals

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -183,10 +183,18 @@ fi
 # }}}
 
 # early helper functions {{{
-GOOD='[32;01m'
-BAD='[31;01m'
-WARN='[33;01m'
-NORMAL='[0m'
+# skip colors when running within a dumb terminal
+if [ "${TERM}" = "dumb" ] ; then
+  GOOD=
+  BAD=
+  WARN=
+  NORMAL=
+else
+  GOOD='[32;01m'
+  BAD='[31;01m'
+  WARN='[33;01m'
+  NORMAL='[0m'
+fi
 
 einfo() {
   einfon "$1\\n"


### PR DESCRIPTION
This avoids having output like follows in Jenkins console output:

| �[32;01m*�[0m grml-debootstrap [0.93] - Please recheck configuration before execution:

Closes: grml/grml-debootstrap#159