### PR TITLE
EFI support: check for efivarfs to support Debian kernels >=5.10

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -595,8 +595,18 @@ efi_setup() {
   echo "Mounting $EFI on /boot/efi"
   mount "$EFI" /boot/efi || return 1
 
+  # if efivarfs kernel module is loaded, but efivars isn't,
+  # then we need to mount efivarfs for efibootmgr usage
+  if ! ls /sys/firmware/efi/efivars/* &>/dev/null ; then
+    echo "Mounting efivarfs on /sys/firmware/efi/efivars"
+    mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+  fi
+
   echo "Invoking efibootmgr"
   efibootmgr || return 1
+
+  umount /sys/firmware/efi/efivars &>/dev/null || true
+
 }
 
 # grub configuration/installation {{{

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -996,7 +996,12 @@ format_efi_partition() {
 # check for EFI support or try to enable it {{{
 efi_support() {
   local efivars_loaded=false
+  # this is for kernels versions before v3.10, which didn't provide efivarfs yet
   if modprobe efivars &>/dev/null ; then
+    efivars_loaded=true
+  fi
+  # kernel versions v3.10 and newer usually provide efivarfs
+  if modprobe efivarfs &>/dev/null ; then
     efivars_loaded=true
   fi
 


### PR DESCRIPTION
CONFIG_EFI_VARS is no longer available since
https://salsa.debian.org/kernel-team/linux/-/commit/20146398c4599147244ed3ffc54f38d07fb8dea3
(tagged initially as debian/5.10.1-1_exp1 + shipped with kernel package
5.10.1-1~exp1 and newer, incl. 5.10.38-1 as present in current
Debian/unstable). Therefore the kernel module efivars is no longer
available on more recent Debian kernel systems.

Quoting from https://wiki.debian.org/UEFI:

| The older interface was efivars, showing files under
| /sys/firmware/efi/vars, and this is what was used by default in both
| Wheezy and Jessie.
|
| The new interface is efivarfs, which will expose things in a slightly
| different format under /sys/firmware/efi/efivars. This is the new
| preferred way of using UEFI configuration variables, and Debian switched
| to it by default from Stretch onwards.

CONFIG_EFI_VARS is no longer required, instead efivarfs seems to be
available starting with kernel v3.10 and newer (see linux.git):

| commit a9499fa7cd3fd4824a7202d00c766b269fa3bda6
| Author: Tom Gundersen <teg@jklm.no>
| Date:   Fri Feb 8 15:37:06 2013 +0000
|
|     efi: split efisubsystem from efivars
|
|     This registers /sys/firmware/efi/{,systab,efivars/} whenever EFI is enabled
|     and the system is booted with EFI.
|
|     This allows
|      *) userspace to check for the existence of /sys/firmware/efi as a way
|         to determine whether or it is running on an EFI system.
|      *) 'mount -t efivarfs none /sys/firmware/efi/efivars' without manually
|         loading any modules.
|
|     [ Also, move the efivar API into vars.c and unconditionally compile it.
|       This allows us to move efivars.c, which now only contains the sysfs
|       variable code, into the firmware/efi directory. Note that the efivars.c
|       filename is kept to maintain backwards compatability with the old
|       efivars.ko module. With this patch it is now possible for efivarfs
|       to be built without CONFIG_EFI_VARS - Matt ]

and:

| commit d68772b7c83f4b518be15ae96f4827c8ed02f684
| Author: Matt Fleming <matt.fleming@intel.com>
| Date:   Fri Feb 8 16:27:24 2013 +0000
|
|     efivarfs: Move to fs/efivarfs
|
|     Now that efivarfs uses the efivar API, move it out of efivars.c and
|     into fs/efivarfs where it belongs. This move will eventually allow us
|     to enable the efivarfs code without having to also enable
|     CONFIG_EFI_VARS built, and vice versa.
|
|     Furthermore, things like,
|
|         mount -t efivarfs none /sys/firmware/efi/efivars
|
|     will now work if efivarfs is built as a module without requiring the
|     use of MODULE_ALIAS(), which would have been necessary when the
|     efivarfs code was part of efivars.c.

Thanks to Volodymyr Fedorov + Manuel Montecelo for spotting this