### PR TITLE
Use "errors=remount-ro" fstab option only within supported filesystems

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -479,11 +479,16 @@ createfstab(){
 EOF
 
   if [ -n "$TARGET_UUID" ] ; then
-    local rootfs_mount_options=",errors=remount-ro"
+    local rootfs_mount_options=""
+
+    if [ -z "${FILESYSTEM}" ] ; then
+      FILESYSTEM="$(blkid -o value -s TYPE /dev/disk/by-uuid/"${TARGET_UUID}")"
+    fi
+
     case "${FILESYSTEM}" in
-      f2fs)
-        # errors=remount-ro is unsupported, see https://github.com/grml/grml-debootstrap/issues/163
-        rootfs_mount_options=""
+      # errors=remount-ro is supported only by a few file systems
+      ext*|exfat|fat|jfs|nilfs2|vfat)
+        rootfs_mount_options=",errors=remount-ro"
         ;;
     esac
 


### PR DESCRIPTION
Also XFS doesn't support the errors=remount-ro option, but instead of disabling the option for file systems that don't support it, let's only enable it for the once that support it (according to linux's source).

Thanks: Chris Hofstaedtler for the bug report
Closes: https://github.com/grml/grml-debootstrap/issues/199