### PR TITLE
Ensure to have filesystem tools installed

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -525,6 +525,28 @@ fstab() {
 }
 # }}}
 
+# ensure we have according filesystem tools available {{{
+install_fs_tools() {
+  local pkg=""
+
+  # note: this is supposed to be coming either via command lines'
+  # $_opt_filesystem or via createfstab()
+  case "${FILESYSTEM}" in
+    jfs)
+      pkg="jfsutils"
+      ;;
+    xfs)
+      pkg="xfsprogs"
+      ;;
+  esac
+
+  if [ -n "${pkg:-}" ] && ! dpkg --list "${pkg}" 2>/dev/null | grep -q '^ii' ; then
+    echo "Filesystem package ${pkg} not present, installing now"
+    DEBIAN_FRONTEND=$DEBIAN_FRONTEND $APTINSTALL "${pkg}"
+  fi
+}
+# }}}
+
 # set up hostname {{{
 hostname() {
   if [ -n "$HOSTNAME" ] ; then
@@ -746,7 +768,8 @@ trap signal_handler HUP INT QUIT TERM
 
  for i in chrootmirror grmlrepos backportrepos kernelimg_conf \
      kernel packages extrapackages reconfigure hosts \
-     default_locales timezone fstab hostname initrd grub_install passwords \
+     default_locales timezone fstab install_fs_tools hostname \
+     initrd grub_install passwords \
      custom_scripts upgrade_system remove_apt_cache services \
      remove_chrootmirror; do
      if stage $i ; then


### PR DESCRIPTION
When installing to an XFS root partition, update-initramfs complains:

| update-initramfs: Generating /boot/initrd.img-5.10.0-19-amd64 | W: /sbin/fsck.xfs doesn't exist, can't install to initramfs

Let's make sure to have the according filesystem package available.

FTR, no need for handling ext* + e2fsprogs, as this is available anyways due to `Priority: required`.

Also, the "--filesystem jfs" isn't supported by default (as mkfs.jfs expects user input unless invoked with -q, something we might wanna automate in the future?), but someone can prepare it manually and install it to the mounted file system, so let's also handle this.

Thanks: Chris Hofstaedtler for the bug report
Closes: https://github.com/grml/grml-debootstrap/issues/200