### PR TITLE
Disable ext4 metadata_csum_seed for Debian releases older than bookworm

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1311,6 +1311,24 @@ mkfs() {
     esac
   fi
 
+  # starting with e2fsprogs v1.47.0 mkfs.ext4 enables the metadata_csum_seed feature
+  # by default, which requires Linux kernel >=4.4, e2fsprogs >=1.43, according GRUB etc.
+  # Disable this feature for Debian releases older than bookworm
+  if [ -n "$MKFS" ] && [ "$MKFS" = "mkfs.ext4" ] ; then
+    case "$RELEASE" in
+      lenny|squeeze|wheezy|jessie|stretch|buster|bullseye)
+        local e2fsprogs_version
+        # assume a more recent version if we can't identify the version via dpkg-query
+        e2fsprogs_version="$(dpkg-query --show --showformat='${Version}' e2fsprogs 2>/dev/null || echo 1.47)"
+        if [ -n "$e2fsprogs_version" ] && dpkg --compare-versions "$e2fsprogs_version" ge '1.43' ; then
+          einfo "Disabling metadata_csum_seed feature for $MKFS as $RELEASE doesn't support it."
+          MKFS_OPTS="$MKFS_OPTS -O ^metadata_csum_seed"
+          eend 0
+        fi
+        ;;
+    esac
+  fi
+
   if [ -n "$MKFS" ] ; then
     einfo "Running $MKFS $MKFS_OPTS on $TARGET"
     # shellcheck disable=SC2086


### PR DESCRIPTION
As of e2fsprogs v1.43 and Linux kernel v4.4 the ext4 file system supports the new metadata_csum_seed feature (which allows the file system UUID to be modified without needing to update all of the file system metadata). Also see https://bugs.debian.org/1031325

Starting with e2fsprogs v1.47 this new metadata_csum_seed feature gets enabled by default. When installing an older Debian release this might cause problems because it's not fully supported yet, see e.g. the GRUB failure documented as #866603.

To keep the behavior identical to Debian, we do not enable the metadata_csum_seed feature for Debian releases before bookworm.  This is relevant for us, as grml-debootstrap might be running from a more recent Debian release (like a Debian testing/unstable based Grml live system).

We check for the e2fsprogs version as versions before 1.43 didn't support the metadata_csum_seed option yet.

Closes: https://bugs.debian.org/1031416
Closes: https://github.com/grml/grml-debootstrap/issues/204