### PR TITLE
add `Depends:` `dosfstools`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Architecture: all
 Depends:
  debian-archive-keyring,
  debootstrap (>= 0.3.3.3) | cdebootstrap (>= 0.3.16) | mmdebstrap,
+ dosfstools,
  e2fsprogs,
  fdisk | util-linux (<< 2.29.2-3~),
  gawk,


### PR DESCRIPTION
since required for builds with `--vmefi`

fixes https://github.com/grml/grml-debootstrap/issues/225