### PR TITLE
Fix compatibility with libpam-tmpdir.

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1811,6 +1811,8 @@ preparechroot() {
   [ -n "$TUNE2FS" ]             && echo "TUNE2FS='$(sed "s,','\\\\'',g" <<<"${TUNE2FS}")'"                         >> "$CHROOT_VARIABLES"
   [ -n "$VMSIZE" ]              && echo "VMSIZE='$(sed "s,','\\\\'',g" <<<"${VMSIZE}")'"                           >> "$CHROOT_VARIABLES"
 
+  [ -n "$TMPDIR" ] && mkdir --parents "${MNTPOINT}/${TMPDIR}"
+
   cp $VERBOSE "${CONFFILES}"/chroot-script "${MNTPOINT}"/bin/chroot-script
   chmod 755 "${MNTPOINT}"/bin/chroot-script
   [ -d "$MNTPOINT"/etc/debootstrap/ ] || mkdir "$MNTPOINT"/etc/debootstrap/

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1811,7 +1811,7 @@ preparechroot() {
   [ -n "$TUNE2FS" ]             && echo "TUNE2FS='$(sed "s,','\\\\'',g" <<<"${TUNE2FS}")'"                         >> "$CHROOT_VARIABLES"
   [ -n "$VMSIZE" ]              && echo "VMSIZE='$(sed "s,','\\\\'',g" <<<"${VMSIZE}")'"                           >> "$CHROOT_VARIABLES"
 
-  [ -n "$TMPDIR" ] && mkdir --parents "${MNTPOINT}/${TMPDIR}"
+  [ -n "$TMPDIR" ] && mkdir --parents "${MNTPOINT}/${TMPDIR}" && chmod 1777 "${MNTPOINT}/${TMPDIR}"
 
   cp $VERBOSE "${CONFFILES}"/chroot-script "${MNTPOINT}"/bin/chroot-script
   chmod 755 "${MNTPOINT}"/bin/chroot-script


### PR DESCRIPTION
By creating folder the required temporary folder.

fixes https://github.com/grml/grml-debootstrap/issues/232