### PR TITLE
Drop support for installing releases before jessie

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -730,26 +730,13 @@ grub_install() {
      done
      rm -f /boot/grub/device.map
   else
-     echo "Installing grub on ${GRUB}:"
-     case "$RELEASE" in
-       lenny|squeeze|wheezy)
-         local grub_dev
-         grub_dev="$(readlink -f "${GRUB}")"
-         if ! grub-install --no-floppy "${grub_dev}" ; then
-           echo "Error: failed to execute 'grub-install --no-floppy ${grub_dev}'." >&2
-           exit 1
-         fi
-         rm -f /boot/grub/device.map
-         ;;
-       *)
-         echo "(hd0) ${GRUB}" > /boot/grub/device.map
-         if ! grub-install "(hd0)" ; then
-           echo "Error: failed to execute 'grub-install (hd0)'." >&2
-           exit 1
-         fi
-         rm /boot/grub/device.map
-         ;;
-     esac
+    echo "Installing grub on ${GRUB}:"
+    echo "(hd0) ${GRUB}" > /boot/grub/device.map
+    if ! grub-install "(hd0)" ; then
+      echo "Error: failed to execute 'grub-install (hd0)'." >&2
+      exit 1
+    fi
+    rm /boot/grub/device.map
   fi
 
   echo "Adjusting grub configuration for use on ${GRUB}."

--- a/chroot-script
+++ b/chroot-script
@@ -101,20 +101,10 @@ chrootmirror() {
     fi
   fi
 
-  # LTS support
-  case "$RELEASE" in
-    squeeze)
-      if [ -n "$MIRROR" ] ; then
-        echo "Release matching $RELEASE - enabling LTS support in sources.list"
-        echo "deb $MIRROR ${RELEASE}-lts $COMPONENTS" >> /etc/apt/sources.list
-      fi
-      ;;
-  esac
-
   # add security.debian.org:
   case "$RELEASE" in
-    unstable|sid|lenny) ;;  # no security pool available
-    squeeze|wheezy|jessie|stretch|buster)
+    unstable|sid) ;;  # no security pool available
+    jessie|stretch|buster)
       echo "Adding security.debian.org to sources.list."
       echo "deb http://security.debian.org ${RELEASE}/updates $COMPONENTS" >> /etc/apt/sources.list
       ;;

--- a/chroot-script
+++ b/chroot-script
@@ -717,6 +717,10 @@ grub_install() {
      echo "Error: grub-install not available. (Error while installing grub package?)" >&2
      return 1
   fi
+  if ! [ -x "$(command -v update-grub)" ] ; then
+     echo "Error: update-grub not available. (Error while installing grub package?)" >&2
+     return 1
+  fi
 
   if [ -n "$SELECTED_PARTITIONS" ] ; then # using sw-raid
      for device in $SELECTED_PARTITIONS ; do
@@ -741,16 +745,6 @@ grub_install() {
 
   echo "Adjusting grub configuration for use on ${GRUB}."
 
-  # finally install grub
-  if [ -x /usr/sbin/update-grub ] ; then
-     UPDATEGRUB='/usr/sbin/update-grub'
-  elif [ -x /sbin/update-grub ] ; then
-     UPDATEGRUB='/sbin/update-grub'
-  else
-    echo "Error: update-grub not available, can not execute it." >&2
-    return 1
-  fi
-
   if [ -n "${BOOT_APPEND}" ] ; then
     echo "Adding BOOT_APPEND configuration ['${BOOT_APPEND}'] to /etc/default/grub."
     sed -i "/GRUB_CMDLINE_LINUX_DEFAULT/ s#\"\$# ${BOOT_APPEND}\"#" /etc/default/grub
@@ -758,7 +752,8 @@ grub_install() {
 
   mountpoint /boot/efi &>/dev/null && umount /boot/efi
 
-  $UPDATEGRUB
+  # finally install grub. Existence of update-grub is checked above.
+  update-grub
 }
 # }}}
 

--- a/chroot-script
+++ b/chroot-script
@@ -337,14 +337,15 @@ get_kernel_version() {
       return 1
   esac
 
-  for KPREFIX in "" "2.6-" ; do  # iterate through the kernel prefixes,
-                                 # currently "" and "2.6-"
-    if package_exists linux-image-${KPREFIX}${KARCH} ; then
-      echo ${KPREFIX}${KARCH}
-      return 0
-    fi
+  local KPACKAGE
+  KPACKAGE=linux-image-"${KPREFIX}${KARCH}"
+  if package_exists "$KPACKAGE"; then
+    echo "${KPREFIX}${KARCH}"
+    return 0
+  fi
 
-  done
+  echo "Expected kernel package $KPACKAGE not found" >&2
+  return 1
 }
 
 # install kernel packages {{{

--- a/chroot-script
+++ b/chroot-script
@@ -324,11 +324,7 @@ get_kernel_version() {
   # shellcheck disable=SC2153
   case "$ARCH" in
     i386)
-      case "$RELEASE" in
-        lenny|squeeze|wheezy) KARCH='686' ;;
-        # since jessie the linux-image-686 image doesn't exist any longer
-        *) KARCH='686-pae' ;;
-      esac
+      KARCH='686-pae'
       ;;
     amd64)
       KARCH='amd64'

--- a/config
+++ b/config
@@ -72,7 +72,7 @@
 # BACKPORTREPOS='yes'
 
 # Debian release that should be installed.
-# Supported values: lenny, squeeze, wheezy, jessie, stretch, buster, bullseye, sid
+# Supported values: jessie, stretch, buster, bullseye, sid
 # Default: 'bullseye'
 # RELEASE='bullseye'
 

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Package: grml-debootstrap
 Architecture: all
 Depends:
  debian-archive-keyring,
- debootstrap (>= 0.3.3.3) | cdebootstrap (>= 0.3.16) | mmdebstrap,
+ debootstrap (>= 1.0.65) | cdebootstrap (>= 0.3.16) | mmdebstrap,
  dosfstools,
  e2fsprogs,
  fdisk | util-linux (<< 2.29.2-3~),

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -926,16 +926,10 @@ while IFS= read -r i; do
   NUM_PARTITIONS=$(( NUM_PARTITIONS + 1 ))
 done < "$TMPFILE"
 
-# force metadata version 0.90 for lenny so old grub can boot from this array.
-METADATA_VERSION=""
-if [ "$RELEASE" = "lenny" ]; then
-   METADATA_VERSION="-e0"
-fi
-
 ERRORFILE=$(mktemp)
 # shellcheck disable=SC2086
 yes | mdadm --create "${TARGET}" --level="${RAIDLEVEL}" \
-      --raid-devices="${NUM_PARTITIONS}" ${METADATA_VERSION} ${SELECTED_PARTITIONS} >/dev/null 2>$ERRORFILE
+      --raid-devices="${NUM_PARTITIONS}" ${SELECTED_PARTITIONS} >/dev/null 2>$ERRORFILE
 RC=$?
 if [ "$RC" = 0 ] ; then
    dialog --title "$PN" --msgbox \

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1618,15 +1618,7 @@ grub_install() {
       eerror "Error: grub not installed inside Virtual Machine. Can not install bootloader." ; eend 1
       bailout 1
     fi
-
-    case "$RELEASE" in
-      lenny|squeeze|wheezy)
-        cp "${MNTPOINT}"/usr/lib/grub/i386-pc/* "${MNTPOINT}/boot/grub/"
-        ;;
-      *)
-        cp -a "${MNTPOINT}"/usr/lib/grub/i386-pc "${MNTPOINT}/boot/grub/"
-        ;;
-    esac
+    cp -a "${MNTPOINT}"/usr/lib/grub/i386-pc "${MNTPOINT}/boot/grub/"
 
     if [ -n "$VMEFI" ]; then
 

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -601,7 +601,7 @@ done
 [ "$_opt_contrib" ]             && COMPONENTS="$COMPONENTS contrib"
 
 case "${RELEASE}" in
-  lenny|squeeze|wheezy|jessie|stretch|buster|bullseye)
+  jessie|stretch|buster|bullseye)
     [ "$_opt_non_free" ] && COMPONENTS="$COMPONENTS non-free"
     ;;
   *)
@@ -1297,7 +1297,7 @@ mkfs() {
   # so disable this feature for older Debian releases where it's known to be unsupported
   if [ -n "$MKFS" ] && [ "$MKFS" = "mkfs.ext4" ] ; then
     case "$RELEASE" in
-      lenny|squeeze|wheezy|jessie)
+      jessie)
         # assume a more recent version if we can't identify the version via dpkg-query
         local e2fsprogs_version
         e2fsprogs_version="$(dpkg-query --show --showformat='${Version}' e2fsprogs 2>/dev/null || echo 1.44)"
@@ -1314,7 +1314,7 @@ mkfs() {
   # Disable this feature for Debian releases older than bookworm
   if [ -n "$MKFS" ] && [ "$MKFS" = "mkfs.ext4" ] ; then
     case "$RELEASE" in
-      lenny|squeeze|wheezy|jessie|stretch|buster|bullseye)
+      jessie|stretch|buster|bullseye)
         local e2fsprogs_version
         # assume a more recent version if we can't identify the version via dpkg-query
         e2fsprogs_version="$(dpkg-query --show --showformat='${Version}' e2fsprogs 2>/dev/null || echo 1.47)"

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -218,8 +218,8 @@ Options and environment variables
 
 *-r*, *--release* _releasename_::
 
-    Specify release of new Debian system. Supported releases names: lenny,
-    squeeze, wheezy, jessie, stretch, buster, bullseye, bookworm and sid.
+    Specify release of new Debian system. Supported releases names:
+    jessie, stretch, buster, bullseye, bookworm and sid.
     Corresponding with configuration variable RELEASE. Default release: bookworm
 
 *--remove-configs*::
@@ -410,7 +410,7 @@ Where do you want to install grub to? Usage example: grub=/dev/sda
   release=...
 
 Specify release of new Debian system. Defaults to Debian bookworm.
-Supported releases: lenny, squeeze, wheezy, jessie, stretch, buster, bullseye, bookworm and sid.
+Supported releases: jessie, stretch, buster, bullseye, bookworm and sid.
 Usage example: release=bullseye
 
   mirror=...
@@ -445,11 +445,12 @@ Supported Releases
 include::releasetable.txt[]
 
 [NOTE]
-.lenny/squeeze/wheezy/jessie/stretch/buster release
+.jessie/stretch/buster release
 ================================================================================
-[1] Please notice that releases like lenny, squeeze, wheezy, jessie, stretch and buster are unsupported releases within Debian nowadays.
-grml-debootstrap can handle the releases but you really should not use them
-anymore unless you really know what you are doing.
+[1] Please notice that releases like jessie, stretch and buster are unsupported releases within Debian nowadays.
+grml-debootstrap can handle the releases but you really should not use them anymore unless you really know what you are doing.
+Even older versions are also entirely unsupported by grml-debootstrap.
+
 Choose the current Debian stable version instead.
 See https://wiki.debian.org/DebianReleases for the list of supported releases.
 

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -463,26 +463,6 @@ throwing segfaults during debootstrap. This can be identified by the following m
    dpkg[...]: segfault at [...]
 
 To work around this issue boot your system with the kernel boot option 'vsyscall=emulate'.
-
-You also need to specify a filesystem that's supported by lenny, e.g.
-'--filesystem ext3' since grml-debootstrap's current default (ext4) isn't
-supported by lenny.
-
-Also when debootstrapping lenny on a live system with a kernel version
-like "3.16-1-grml-amd64" lenny's libc will fail to install with:
-
-   [...]
-   /var/lib/dpkg/tmp.ci/preinst: line 265: [: 3.16-1-grml-amd64: integery expression expected
-   /var/lib/dpkg/tmp.ci/preinst: line 231: 3.16-1-grml-amd64: syntax error: invalid arithemtic operator (error token is ".16-1-grml-amd64")
-   dpkg: error processing /var/cache/apt/archives/libc6_2.7-18lenny7_amd64.deb (--install):
-   [....]
-
-To workaround this either debootstrap from a system with an according
-kernel version or use the "fake uname" workaround (just google for it).
-
-When installing lenny to a new mdraid, grml-debootstrap will use md metadata
-format version 0.90. This limits the device to a maximum size of 2TB, but has
-the advantage of grub-legacy actually being able to boot from it.
 ================================================================================
 
 [NOTE]

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -45,17 +45,5 @@ stretch: clean fake-uname.so install
 jessie: clean fake-uname.so install
 	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
 
-# Debian 7
-wheezy: clean fake-uname.so install
-	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
-
-# Debian 6.0
-squeeze: clean fake-uname.so install
-	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
-
-# Debian 5.0
-lenny: clean fake-uname.so install
-	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
-
-.PHONY: compile bullseye buster stretch jessie wheezy squeeze lenny
+.PHONY: compile bullseye buster stretch jessie
 .NOTPARALLEL:

--- a/packer/debian64_provision.sh
+++ b/packer/debian64_provision.sh
@@ -32,13 +32,6 @@ trap 'bailout ${LINENO} $?' ERR
 
 ## helper functions
 virtualbox_setup() {
-  case "$DEBIAN_VERSION" in
-    lenny)
-      echo "* Debian lenny doesn't support Virtualbox Guest Additions, skipping."
-      return 0
-      ;;
-  esac
-
   if ! mountpoint "${TARGET}" &>/dev/null ; then
     echo "* Mounting target system"
     mount "${INSTALL_TARGET}" "${TARGET}"
@@ -115,12 +108,8 @@ vagrant_setup() {
   chroot ${TARGET} chown vagrant:vagrant /home/vagrant/.ssh /home/vagrant/.ssh/authorized_keys
 
   echo "* Setting up sudo configuration for user vagrant"
-  if ! [ -d "${TARGET}/etc/sudoers.d" ] ; then # lenny:
-    echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> "${TARGET}/etc/sudoers"
-  else # wheezy and newer:
-    echo "vagrant ALL=(ALL) NOPASSWD: ALL" > "${TARGET}/etc/sudoers.d/vagrant"
-    chmod 0440 "${TARGET}/etc/sudoers.d/vagrant"
-  fi
+  echo "vagrant ALL=(ALL) NOPASSWD: ALL" > "${TARGET}/etc/sudoers.d/vagrant"
+  chmod 0440 "${TARGET}/etc/sudoers.d/vagrant"
 
   host="$(cat ${TARGET}/etc/hostname)"
   if ! grep -q "${host}$" "${TARGET}"/etc/hosts ; then

--- a/packer/debian64_provision.sh
+++ b/packer/debian64_provision.sh
@@ -203,29 +203,8 @@ EOF
   fi
 }
 
-verify_debootstrap_version() {
-  local required_version=1.0.65
-  local present_version=$(dpkg-query --show --showformat='${Version}' debootstrap)
-
-  if dpkg --compare-versions $present_version lt $required_version ; then
-    echo "** debootstrap version $present_version is older than minimum required version $required_version - upgrading."
-    apt-get update
-    apt-get -y install debootstrap
-  fi
-}
-
 grml_debootstrap_execution() {
   echo "* Installing Debian"
-
-  # release specific stuff
-  case "$DEBIAN_VERSION" in
-    lenny)
-      GRML_DEB_OPTIONS="--mirror http://archive.debian.org/debian/ --filesystem ext3"
-      ;;
-    stretch)
-      verify_debootstrap_version
-      ;;
-  esac
 
   echo "** Executing: $GRML_DEBOOTSTRAP --hostname $DEBIAN_VERSION --release $DEBIAN_VERSION --target ${INSTALL_TARGET} --grub ${GRUB_TARGET} --password grml --force $GRML_DEB_OPTIONS" | tee -a /tmp/grml-debootstrap.log
   $GRML_DEBOOTSTRAP --hostname "${DEBIAN_VERSION}" --release "${DEBIAN_VERSION}" --target "${INSTALL_TARGET}" --grub "${GRUB_TARGET}" --password grml --force $GRML_DEB_OPTIONS 2>&1 | tee -a /tmp/grml-debootstrap.log

--- a/releasetable.txt
+++ b/releasetable.txt
@@ -2,9 +2,6 @@
 [width="40%",frame="topbot",options="header"]
 |======================
 |Release  |Status
-|lenny    |works[1]
-|squeeze  |works[1]
-|wheezy   |works[1]
 |jessie   |works[1]
 |stretch  |works[1]
 |buster   |works[1]


### PR DESCRIPTION
Whoever wants to install such an old release should please use an older grml-debootstrap.

This lets us drop old code, and going forward rely on new features.

Releases before jessie need vsyscall emulation. Jessie itself can only be installed by overriding both debootstrap's and apt's signing key checks. Stretch needs at least `--no-check-gpg` (or maybe another workaround), but for now it is installable.