### PR TITLE
Remove shadowconfig call

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -384,9 +384,6 @@ passwords()
     return 0
   fi
 
-  echo "Activating shadow passwords."
-  shadowconfig on
-
   CHPASSWD_OPTION=
   if chpasswd --help 2>&1 | grep -q -- '-m,' ; then
      CHPASSWD_OPTION='-m'

--- a/tests/goss.yaml
+++ b/tests/goss.yaml
@@ -1,6 +1,7 @@
 process:
   sshd:
     running: true
+
 file:
   /etc/timezone:
     exists: true
@@ -9,3 +10,9 @@ file:
     filetype: symlink
     exists: true
     linked-to: /usr/share/zoneinfo/Europe/Vienna
+
+  # shadow passwords are enabled.
+  /etc/shadow:
+    exists: true
+  /etc/gshadow:
+    exists: true


### PR DESCRIPTION
passwd.postinst enables shadow passwords for the last 16 years. Add a test instead.