### PR TITLE
ci: fix shellcheck for test scripts

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          path: "."
+          path: tests
           pattern: |
-            tests/*
+            *
           check_all_files_with_shebangs: "false"


### PR DESCRIPTION
Previously the invocation would silently fail. I am still not sure if it always works,