### PR TITLE
consistently use ESP label for the EFI system partition

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1517,7 +1517,7 @@ prepare_vm() {
     if [ "$ARCH" = 'arm64' ]; then
       einfo "Setting up GPT partitions for arm64"
       parted -s "${TARGET}" 'mklabel gpt'
-      parted -s "${TARGET}" 'mkpart EFI fat32 1MiB 10MiB'
+      parted -s "${TARGET}" 'mkpart ESP fat32 1MiB 10MiB'
       parted -s "${TARGET}" 'set 1 boot on'
       parted -s "${TARGET}" 'mkpart LINUX ext4 10MiB 100%'
     else


### PR DESCRIPTION
change from EFI to ESP for arm64 builds

Use of ESP is more popular.

* https://en.wikipedia.org/wiki/EFI_system_partition
* https://wiki.archlinux.org/title/EFI_system_partition
* https://www.diskpart.com/articles/efi-system-partition-4348.html

If we'd use the long label it would be "EFI system partition" but since we use the short label it should be ESP.

Why bother? Because then later `PARTLABEL` can be used in `/etc/fstab`.

https://wiki.archlinux.org/title/fstab#GPT_partition_labels

Any label with spaces is more error-prone.

I haven't found any convention for partition labels but consistency makes sense.