### PR TITLE
Install busybox On Debian/stretch as it's required for initramfs

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -349,6 +349,13 @@ kernel() {
   $APTUPDATE
   KVER=$(get_kernel_version)
   if [ -n "$KVER" ] ; then
+    case "$RELEASE" in
+      stretch)
+        echo "Installing busybox on Debian/$RELEASE as it's essential for the initramfs"
+        DEBIAN_FRONTEND=$DEBIAN_FRONTEND $APTINSTALL busybox
+        ;;
+    esac
+
      KERNELPACKAGES="linux-image-$KVER linux-headers-$KVER firmware-linux-free $INITRD_GENERATOR"
      # only add firmware-linux if we have non-free as a component
      if expr "$COMPONENTS" : '.*non-free' >/dev/null ; then


### PR DESCRIPTION
Followup fix for 2708f441697d1b9

Thanks: @adrelanos  for spotting and reporting
Closes: https://github.com/grml/grml-debootstrap/issues/256

Failure with stretch:
```
Processing triggers for initramfs-tools (0.130) ...
update-initramfs: Generating /boot/initrd.img-4.9.0-13-amd64
E: busybox or busybox-static, version 1:1.22.0-17~ or later, is required but not installed
update-initramfs: failed for /boot/initrd.img-4.9.0-13-amd64 with 1.
dpkg: error processing package initramfs-tools (--configure):
 subprocess installed post-installation script returned error exit status 1
[...]
invoke-rc.d: policy-rc.d denied execution of try-restart.
Errors were encountered while processing:
 initramfs-tools
E: Sub-process /usr/bin/dpkg returned an error code (1)
```