### PR TITLE
ci: enable test-build on pushes to branches and periodic

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,10 @@
 name: test-build
 on:
   pull_request:
+  push:
+  schedule:
+    - cron: '30 3 * * 2'
+
 concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: true


### PR DESCRIPTION
Enables test builds on pushes, to all branches. Assumes people usually work on their own fork. They can enable/disable GitHub Actions on their forks as needed.

Also enables a periodic test build (on Tuesdays), so we know when Debian testing breaks or similar.
