### PR TITLE
use apt-get with --error-on=any option

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -42,7 +42,7 @@ if [ -x /usr/bin/aptitude ] ; then
    fi
 else
    APTINSTALL="apt-get -y --no-install-recommends install $DPKG_OPTIONS"
-   APTUPDATE="apt-get update $DPKG_OPTIONS"
+   APTUPDATE="apt-get --error-on=any update $DPKG_OPTIONS"
    APTUPGRADE="apt-get -y upgrade $DPKG_OPTIONS"
 fi
 


### PR DESCRIPTION
for better error handling

Otherwise if 1 repository fails (such as the security repository) apt would by default silently ignore this can continue the build. Therefore for consistent builds and towards reproducible builds, this option is required.

I am using this in all my build scripts for years, though injected through DPKG_OPTIONS but I think the case is strong enough to hardcode this as default.
