### PR TITLE
enable `discard` mount option by default in `/etc/fstab`

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -492,7 +492,7 @@ EOF
     case "${FILESYSTEM}" in
       # errors=remount-ro is supported only by a few file systems
       ext*|exfat|fat|jfs|nilfs2|vfat)
-        rootfs_mount_options=",errors=remount-ro"
+        rootfs_mount_options="discard,errors=remount-ro"
         ;;
     esac
 


### PR DESCRIPTION
This is for easier `trim` support in VMs to release the free space on the host operating system after deleting files inside the VM image.
