### PR TITLE
Move try_umount above cleanup()

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -247,6 +247,32 @@ check4progs(){
 }
 # }}}
 
+# unmount mountpoint {{{
+try_umount() {
+  local tries=$1
+  local mountpoint="$2"
+
+  if ! mountpoint "$mountpoint" &>/dev/null ; then
+    return 0
+  fi
+
+  for (( try=1; try<=tries; try++ )); do
+    if [[ ${try} -eq ${tries} ]]; then
+      # Last time, show errors this time
+      umount "${mountpoint}" && return 0
+    else
+      # Not last time, hide errors until fatal
+      if umount "${mountpoint}" 2>/dev/null ; then
+        return 0
+      else
+        sleep 1
+      fi
+    fi
+  done
+  return 1  # Tried enough
+}
+# }}}
+
 # helper functions {{{
 cleanup() {
   if [ -n "$CHROOT_VARIABLES" ] ; then
@@ -2009,32 +2035,6 @@ execute_post_scripts() {
       fi
     done
   fi
-}
-# }}}
-
-# unmount mountpoint {{{
-try_umount() {
-  local tries=$1
-  local mountpoint="$2"
-
-  if ! mountpoint "$mountpoint" &>/dev/null ; then
-    return 0
-  fi
-
-  for (( try=1; try<=tries; try++ )); do
-    if [[ ${try} -eq ${tries} ]]; then
-      # Last time, show errors this time
-      umount "${mountpoint}" && return 0
-    else
-      # Not last time, hide errors until fatal
-      if umount "${mountpoint}" 2>/dev/null ; then
-        return 0
-      else
-        sleep 1
-      fi
-    fi
-  done
-  return 1  # Tried enough
 }
 # }}}
 


### PR DESCRIPTION
`try_umount()` replaced all umount calls in PR #264.

Unfortunately, the function is defined too late for a few of functions, especially for cleanup(), which fails with:

```
   -> Failed (rc=1)
  /sbin/grml-debootstrap: line 260: try_umount: command not found
  Unexpected non-zero exit code 127 in /sbin/grml-debootstrap /sbin/grml-debootstrap /sbin/grml-debootstrap /sbin/grml-debootstrap /sbin/grml-debootstrap at line 260 329 1107 1179 0 detected!
  last bash command: try_umount 3 "${MNTPOINT}"/boot/efi
   -> Failed (rc=1)
  /sbin/grml-debootstrap: line 260: try_umount: command not found
```

Moved the `try_umount` above `cleanup()`.

Closes: #271