### PR TITLE
GitHub Actions: Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,6 +3,7 @@
 
 name: pr-review
 on:
+  workflow_dispatch:
   pull_request:
 jobs:
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,6 @@
 name: test-build
 on:
+  workflow_dispatch:
   pull_request:
   push:
   schedule:


### PR DESCRIPTION
To manually run a workflow,  the workflow must be configured to run on the workflow_dispatch event.

We want that all our GitHub Actions can be triggered manually.

See:

* https://docs.github.com/en/actions/using-workflows/manually-running-a-workflowk
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch