### PR TITLE
Tag installed policy-rc.d file

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -220,6 +220,7 @@ install_policy_rcd() {
      export POLICYRCD=1
      cat > /usr/sbin/policy-rc.d << EOF
 #!/bin/sh
+# Installed by grml-debootstrap chroot-script.
 exit 101
 EOF
      chmod 775 /usr/sbin/policy-rc.d


### PR DESCRIPTION
Useful in case it is not cleaned up and later on found on an installed system.