### PR TITLE
GitHub Actions: raise upload-artifact + download-artifact to v4

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,7 +33,7 @@ jobs:
         HOST_RELEASE: ${{matrix.host_release}}
 
     - name: Archive built .deb
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: deb-${{matrix.host_release}}
         if-no-files-found: error
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download built deb
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: deb-${{matrix.host_release}}
 
@@ -98,7 +98,7 @@ jobs:
         RELEASE: ${{matrix.release}}
 
     - name: Archive VM test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vm-results-${{matrix.host_release}}-${{matrix.release}}-${{matrix.debootstrap}}
         if-no-files-found: error


### PR DESCRIPTION
Fixes:

```
| Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/download-artifact@v3, actions/upload-artifact@v3.
| For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Related to grml/grml-debootstrap#278

Thanks: Darshaka Pathirana