### PR TITLE
tests: capture screenshot on failure

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -99,6 +99,7 @@ jobs:
 
     - name: Archive VM test results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: vm-results-${{matrix.host_release}}-${{matrix.release}}-${{matrix.debootstrap}}
         if-no-files-found: error

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Tests
+
+The `tests` directory provides scripts and configuration files which are used within [grml-debootstrap's GitHub actions](https://github.com/grml/grml-debootstrap/actions).
+
+> [!CAUTION]
+> executing the scripts is potentially dangerous and may destroy the host system and/or any data. Run the tests only on throw-away systems and at your own risk.
+
+The scripts are **not** designed to be executed manually, though it's possible to run them inside a local Debian throw-away VM.
+
+> [!NOTE]
+> make sure to have at least 8GB disk space and 2GB memory available on your VM.
+
+Execute the following steps to build a Debian VM image (`qemu.img`) and run the tests against it:
+
+```
+sudo apt install git docker.io
+git clone https://github.com/grml/grml-debootstrap
+cd grml-debootstrap
+sudo ./tests/docker-build-deb.sh --autobuild 01
+sudo ./tests/build-vm-and-test.sh setup
+sudo ./tests/build-vm-and-test.sh run
+sudo ./tests/build-vm-and-test.sh test
+```

--- a/tests/build-vm-and-test.sh
+++ b/tests/build-vm-and-test.sh
@@ -34,6 +34,8 @@ fi
 if [ "$1" == "setup" ]; then
   sudo apt-get update
   sudo apt-get -qq -y install curl qemu-system-x86 kpartx python3-pexpect python3-serial
+  # vncsnapshot might not be available, though we don't want to abort execution then
+  sudo apt-get -qq -y install vncsnapshot || true
   [ -x ./tests/goss ] || curl -fsSL https://goss.rocks/install | GOSS_DST="$(pwd)/tests" sh
   # TODO: docker.io
   exit 0

--- a/tests/build-vm-and-test.sh
+++ b/tests/build-vm-and-test.sh
@@ -32,9 +32,9 @@ if [ ! -d ./tests ]; then
 fi
 
 if [ "$1" == "setup" ]; then
-  [ -x ./tests/goss ] || curl -fsSL https://goss.rocks/install | GOSS_DST="$(pwd)/tests" sh
   sudo apt-get update
-  sudo apt-get -qq -y install qemu-system-x86 kpartx python3-pexpect python3-serial
+  sudo apt-get -qq -y install curl qemu-system-x86 kpartx python3-pexpect python3-serial
+  [ -x ./tests/goss ] || curl -fsSL https://goss.rocks/install | GOSS_DST="$(pwd)/tests" sh
   # TODO: docker.io
   exit 0
 fi

--- a/tests/serial-console-connection
+++ b/tests/serial-console-connection
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 import serial
+import os
+import shutil
+import subprocess
 import sys
 import time
 from pexpect import fdpexpect
@@ -24,6 +27,11 @@ parser.add_argument(
     default="180",
     type=int,
     help="Maximum time for finding the login prompt, in seconds",
+)
+parser.add_argument(
+    "--screenshot",
+    default="screenshot.jpg",
+    help="file name for screenshot captured via VNC on error",
 )
 parser.add_argument(
     "--tries",
@@ -74,6 +82,21 @@ def login(ser, hostname, user, password, timeout=5):
     child.expect("%s@%s" % (user, hostname), timeout=timeout)
 
 
+def capture_vnc_screenshot(screenshot_file):
+    if not shutil.which("vncsnapshot"):
+        print("WARN: vncsnapshot not available, skipping vnc snapshot capturing.")
+        return
+
+    print("Trying to capture screenshot via vncsnapshot to", screenshot_file)
+
+    proc = subprocess.Popen(["vncsnapshot", "localhost", screenshot_file])
+    proc.wait()
+    if proc.returncode != 0:
+        print("WARN: failed to capture vnc snapshot :(")
+    else:
+        print("Screenshot file '%s' available" % os.path.abspath(screenshot_file))
+
+
 def main():
     args = parser.parse_args()
     hostname = args.hostname
@@ -81,6 +104,7 @@ def main():
     port = args.port
     user = args.user
     commands = args.command
+    screenshot_file = args.screenshot
 
     ser = serial.Serial(port, 115200)
     ser.flushInput()
@@ -116,6 +140,7 @@ def main():
             # after poweroff, the serial device will probably vanish. do not attempt reading from it anymore.
 
     if not success:
+        capture_vnc_screenshot(screenshot_file)
         sys.exit(1)
 
 

--- a/tests/serial-console-connection
+++ b/tests/serial-console-connection
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import serial
 import sys

--- a/tests/serial-console-connection
+++ b/tests/serial-console-connection
@@ -15,7 +15,7 @@ parser.add_argument(
     help="serial console device to connect " + "to (e.g. /dev/pts/X)",
 )
 parser.add_argument(
-    "--hostname", default="buster", help="hostname of the system for login process"
+    "--hostname", default="bookworm", help="hostname of the system for login process"
 )
 parser.add_argument("--user", default="root", help="user name to use for login")
 parser.add_argument("--password", default="grml", help="password for login")


### PR DESCRIPTION
@mika wrote most of this, I just rebased it on top of #283 

- Capture VM screenshot when tests fail.
- Add instructions for running the tests locally.
- Ensure curl is installed.
- Update default hostname in helper script.

Debugging aid for #278.
