### PR TITLE
shellcheck: restrict shellcheck-tests to tests/*.sh files

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -37,5 +37,5 @@ jobs:
           reporter: github-pr-review
           path: tests
           pattern: |
-            *
+            *.sh
           check_all_files_with_shebangs: "false"

--- a/tests/test-vm.sh
+++ b/tests/test-vm.sh
@@ -135,6 +135,6 @@ echo "Finished serial console connection [timeout=${timeout}]."
 
 mv results/* "$TESTS_RESULTSDIR/"
 
-bailout $RC
+bailout "$RC"
 
 # EOF


### PR DESCRIPTION
For unknown reasons the pr-review shellcheck-tests workflow started reporting shellcheck errors in non-shell files in `tests/`. Supposedly `check_all_files_with_shebangs: "false"` should prevent this, but alas.

Also fix an actual shellcheck issue.
