### PR TITLE
Drop support for debian2hd / AUTOINSTALL

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -970,20 +970,6 @@ fi
 }
 # }}}
 
-# user should recheck his configuration {{{
-# support full automatic installation:
-checkforrun() {
-   dialog --timeout 10 --title "$PN" \
-          --yesno "Do you want to stop at this stage?
-
-Notice: you are running ${PN} in non-interactive mode.
-${PN} will install Debian ${RELEASE} on ${TARGET}.
-Last chance to quit. Timeout of 10 seconds running....
-
-Do you want to stop now?" 0 0 2>/dev/null
-}
-# }}}
-
 # format efi partition {{{
 format_efi_partition() {
   if [ -z "$EFI" ] ; then
@@ -1049,12 +1035,7 @@ if [ -z "$VIRTUAL" ] ; then
   fi
 fi
 
-if [ -n "$AUTOINSTALL" ] ; then
-   if checkforrun ; then
-      eerror "Exiting as requested"
-      bailout 1
-   fi
-elif [ -n "$INTERACTIVE" ] ; then
+if [ -n "$INTERACTIVE" ] ; then
 
    INFOTEXT="Please recheck configuration before execution:
    "
@@ -2169,18 +2150,7 @@ done
 cleanup
 # }}}
 
-# end dialog of autoinstallation {{{
-if [ -n "$AUTOINSTALL" ] ; then
-   if dialog --title "${PN}" --pause "Finished execution of ${PN}.
-Automatically rebooting in 10 seconds.
-
-Choose Cancel to skip rebooting." 10 60 10 ; then
-     noeject noprompt reboot
-  fi
-else
-   einfo "Finished execution of ${PN}. Enjoy your Debian system."
-fi
-# }}}
+einfo "Finished execution of ${PN}. Enjoy your Debian system."
 
 ## END OF FILE #################################################################
 # vim: ai tw=100 expandtab foldmethod=marker shiftwidth=2

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -387,58 +387,6 @@ system then. If you want to install additional packages that are not available
 via the Grml or Debian mirror drop them into /etc/debootstrap/extrapackages and
 make sure that EXTRAPACKAGES is set to "yes".
 
-Automatic installation
-----------------------
-
-If environment variable AUTOINSTALL is set grml-debootstrap can be executed in a
-full automatic mode. While this mode isn't really useful for interactive
-execution (just configure /etc/debootstrap/configure or specify the relevant
-variables on the command line instead) it is meant for use via boot option
-debian2hd on the Grml live system. The boot option debian2hd (more precise: the
-kernelname at the bootprompt) supports the following boot options (they
-correspond with the command line options mentioned above):
-
-  target=...
-
-The target partition/directory of the new Debian system. Usage example:
-target=/dev/sda1
-
-  grub=...
-
-Where do you want to install grub to? Usage example: grub=/dev/sda
-
-  release=...
-
-Specify release of new Debian system. Defaults to Debian bookworm.
-Supported releases: jessie, stretch, buster, bullseye, bookworm and sid.
-Usage example: release=bullseye
-
-  mirror=...
-
-Specify mirror which should be used for apt-get/aptitude instead
-of the default one (http://deb.debian.org/debian).
-Usage example: mirror=ftp://ftp.tugraz.at/mirror/debian
-
-  password=...
-
-Set password of user root without prompting for it but set it to the given
-argument. Usage example: password=AiTh5ahn
-
-Usage example for automatic installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  debian2hd target=/dev/sda1 grub=/dev/sda mirror=ftp://ftp.tugraz.at/mirror/debian password=foobar
-
-You have to enter this command line at the bootprompt of the Grml live system.
-Please make sure that /dev/sda1 is the partition where you really want to
-install your new Debian system.
-
-[NOTE]
-Automatic installation within booting process is done in grml-autoconfig via
-setting environment variable AUTOINSTALL and creation of
-/usr/bin/grml-debootstrap_noninteractive with the available and relevant
-boot options for grml-debootstrap.
-
 Supported Releases
 ------------------
 


### PR DESCRIPTION
grml-autoconfig dropped this, as it is plainly broken under systemd but nobody has complained.

See https://github.com/grml/grml-autoconfig/pull/17