### PR TITLE
interactive mode: ignore failures when identifying file system fails

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -728,7 +728,7 @@ prompt_for_target()
   fi
 
   PARTITION_LIST=$(for i in $AVAILABLE_PARTITIONS ; do
-                     fs="$(blkid -s TYPE -o value "$i" 2>/dev/null)"
+                     fs="$(blkid -s TYPE -o value "$i" 2>/dev/null || true)"
                      [ -n "$fs" ] || fs='[no_filesystem_yet]'
                      echo "$i" "$fs"
                      unset fs


### PR DESCRIPTION
When booting Grml from a YUMI device (see https://yumiusb.com/) which was built with Ventoy, then executing `blkid -s TYPE -o value /dev/dm-0p1` might fail, if ventoy is behind the `/dev/dm-0p1` device:

```
root@grml:~# dmsetup ls
ventoy  (253:0)
```

Fixes:

```
++ for i in $AVAILABLE_PARTITIONS
+++ blkid -s TYPE -o value /dev/dm-0p1
++++ error_handler
++++ last_exit_code=2
++++ last_bash_command='blkid -s TYPE -o value "$i" 2> /dev/null' ++++ echo 'Unexpected non-zero exit code 2 in /usr/sbin/grml-debootstrap /usr/sbin/grml-debootstrap /usr/sbin/grml-debootstrap /usr/sbin/grml-debootstrap at line 744 1151 1166 0 detected! last bash command: blkid -s TYPE -o value "$i" 2> /dev/null' ++++ '[' -r /mnt/debootstrap.5465/debootstrap/debootstrap.log ']'
```

Thanks to klatls for the bug report