### PR TITLE
Make bootloader updates on UEFI-based systems work

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -623,11 +623,11 @@ efi_setup() {
   # then we need to mount efivarfs for efibootmgr usage
   if ! ls /sys/firmware/efi/efivars/* &>/dev/null ; then
     echo "Mounting efivarfs on /sys/firmware/efi/efivars"
-    mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+    mount -t efivarfs efivarfs /sys/firmware/efi/efivars || true
   fi
 
   echo "Invoking efibootmgr"
-  efibootmgr
+  efibootmgr || true
 }
 
 # grub configuration/installation {{{
@@ -667,20 +667,72 @@ device_to_id() {
   return 1
 }
 
+is_grub_bios_compatible() {
+  # Check if the disk uses an MSDOS partition table, these are always compatible
+  if [[ "$(blkid "$GRUB")" =~ 'PTTYPE="dos"' ]]; then
+    return 0
+  # Look for a BIOS boot partition otherwise
+  else
+    while read -r line; do
+      if [[ "$line" =~ ^${GRUB}.*21686148-6449-6e6f-744e-656564454649$ ]]; then
+        return 0
+      fi
+    done < <(lsblk -pnlo NAME,PARTTYPE)
+  fi
+  return 1
+}
+
+run_grub_install() {
+  grub_install_cmd=( 'grub-install' "$@" )
+  if ! "${grub_install_cmd[@]}" ; then
+    echo "Error: failed to execute '${grub_install_cmd[*]}'." >&2
+    exit 1
+  fi
+}
+
 grub_install() {
 
   if [ -z "$GRUB" ] ; then
     echo "Notice: \$GRUB not defined, will not install grub inside chroot at this stage."
     return 0
   fi
+  MAIN_GRUB_PACKAGE=""
+  GRUB_SECBOOT_PACKAGES=()
+
+  case "$ARCH" in
+    i386)
+      if [ -n "$EFI" ]; then
+        MAIN_GRUB_PACKAGE="grub-efi-ia32"
+        GRUB_SECBOOT_PACKAGES=( "grub-efi-ia32-signed" "shim-signed" )
+      elif is_grub_bios_compatible; then
+        MAIN_GRUB_PACKAGE="grub-pc"
+      fi
+      ;;
+    amd64)
+      if is_grub_bios_compatible && [ -n "$EFI" ]; then
+        MAIN_GRUB_PACKAGE="grub-cloud-amd64"
+        GRUB_SECBOOT_PACKAGES=( "grub-efi-amd64-signed" "shim-signed" )
+      elif [ -n "$EFI" ]; then
+        MAIN_GRUB_PACKAGE="grub-efi-amd64"
+        GRUB_SECBOOT_PACKAGES=( "grub-efi-amd64-signed" "shim-signed" )
+      else
+        MAIN_GRUB_PACKAGE="grub-pc"
+      fi
+      ;;
+    arm64)
+      if [ -n "$EFI" ]; then
+        MAIN_GRUB_PACKAGE="grub-efi-arm64"
+        GRUB_SECBOOT_PACKAGES=( "grub-efi-arm64-signed" "shim-signed" )
+      fi
+      ;;
+  esac
+
+  if [ -z "$MAIN_GRUB_PACKAGE" ]; then
+    echo "Notice: No applicable bootloaders found, will not install grub inside chroot at this stage."
+    return 0
+  fi
 
   efi_setup
-
-  if [ -n "$EFI" ] ; then
-    GRUB_PACKAGE=grub-efi-amd64
-  else
-    GRUB_PACKAGE=grub-pc
-  fi
 
   # make sure this is pre-defined so we have sane settings for automated
   # upgrades, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=711019
@@ -691,13 +743,12 @@ grub_install() {
      grub_device="${GRUB}"
   fi
 
-  echo "Setting ${GRUB_PACKAGE} debconf configuration for install device to $GRUB"
-  echo "${GRUB_PACKAGE} ${GRUB_PACKAGE}/install_devices multiselect ${grub_device}" | debconf-set-selections
-
-  if ! dpkg --list "${GRUB_PACKAGE}" 2>/dev/null | grep -q '^ii' ; then
-    echo "Notice: grub option set but no ${GRUB_PACKAGE} package, installing it therefore."
-    DEBIAN_FRONTEND=$DEBIAN_FRONTEND $APTINSTALL "${GRUB_PACKAGE}"
+  echo "Setting grub debconf configuration for install device to $GRUB"
+  if [ -n "$MAIN_GRUB_PACKAGE" ]; then
+    echo "${MAIN_GRUB_PACKAGE} ${MAIN_GRUB_PACKAGE}/install_devices multiselect ${grub_device}" | debconf-set-selections
   fi
+
+  DEBIAN_FRONTEND=$DEBIAN_FRONTEND $APTINSTALL "${MAIN_GRUB_PACKAGE}" "${GRUB_SECBOOT_PACKAGES[@]}"
 
   if ! [ -x "$(command -v grub-install)" ] ; then
      echo "Error: grub-install not available. (Error while installing grub package?)" >&2
@@ -712,19 +763,31 @@ grub_install() {
      for device in $SELECTED_PARTITIONS ; do
         GRUB="${device%%[0-9]}"
         echo "Installing grub on ${GRUB}:"
-        if ! grub-install --no-floppy "$GRUB" ; then
-          echo "Error: failed to execute 'grub-install --no-floppy $GRUB'." >&2
-          exit 1
+        if [ -n "$EFI" ]; then
+          case "${ARCH}" in
+            i386)  run_grub_install --no-floppy --target=i386-efi "${GRUB}";;
+            amd64) run_grub_install --no-floppy --target=x86_64-efi "${GRUB}";;
+            arm64) run_grub_install --no-floppy --target=arm64-efi "${GRUB}";;
+          esac
         fi
-
+        if [ "$MAIN_GRUB_PACKAGE" = 'grub-cloud-amd64' ] || [ -z "$EFI" ]; then
+          run_grub_install --no-floppy --target=i386-pc "${GRUB}"
+        fi
      done
      rm -f /boot/grub/device.map
   else
     echo "Installing grub on ${GRUB}:"
+    mkdir -p /boot/grub
     echo "(hd0) ${GRUB}" > /boot/grub/device.map
-    if ! grub-install "(hd0)" ; then
-      echo "Error: failed to execute 'grub-install (hd0)'." >&2
-      exit 1
+    if [ -n "$EFI" ]; then
+      case "${ARCH}" in
+        i386)  run_grub_install --target=i386-efi "${GRUB}";;
+        amd64) run_grub_install --target=x86_64-efi "${GRUB}";;
+        arm64) run_grub_install --target=arm64-efi "${GRUB}";;
+      esac
+    fi
+    if [ "$MAIN_GRUB_PACKAGE" = 'grub-cloud-amd64' ] || [ -z "$EFI" ]; then
+      run_grub_install --target=i386-pc "${GRUB}"
     fi
     rm /boot/grub/device.map
   fi

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -979,7 +979,9 @@ efi_support() {
     einfo "EFI support detected, but system seems to be running in BIOS mode."
   fi
 
-  return 1
+  # The user may have a legitimate reason to do an EFI installation on a BIOS
+  # system (for instance if doing a hybrid-bootable installation), so don't
+  # return 1 here.
 }
 # }}}
 
@@ -988,15 +990,9 @@ checkconfiguration()
 {
 
 if [ -z "$VIRTUAL" ] ; then
-  if efi_support ; then
-    if [ -z "$_opt_efi" ] ; then
-      ewarn "EFI support detected but no --efi option given, please consider enabling it."
-    fi
-  else
-    if [ -n "$_opt_efi" ] ; then
-      eerror "EFI option used but no EFI support detected."
-      bailout 1
-    fi
+  efi_support
+  if [ -z "$_opt_efi" ] ; then
+    ewarn "EFI support detected but no --efi option given, please consider enabling it."
   fi
 fi
 
@@ -1254,13 +1250,6 @@ mkfs() {
   fi
 
   if [ -n "$MKFS" ] ; then
-
-    if [ -n "${ARM_EFI_TARGET}" ] ; then
-      einfo "Running mkfs.fat $MKFS_OPTS on $ARM_EFI_TARGET"
-      mkfs.fat -n "EFI" "$ARM_EFI_TARGET"
-      MKFS_OPTS="$MKFS_OPTS -L LINUX"
-    fi
-
     einfo "Running $MKFS $MKFS_OPTS on $TARGET"
     # shellcheck disable=SC2086
     "$MKFS" $MKFS_OPTS "$TARGET"
@@ -1427,6 +1416,11 @@ prepare_vm() {
 
   ORIG_TARGET="$TARGET" # store for later reuse
 
+  case "$ARCH" in
+    i386|amd64) true;;
+    arm64)      VMEFI=1;;
+  esac
+
   if [ -n "$VMFILE" ]; then
     qemu-img create -f raw "${TARGET}" "${VMSIZE}"
   fi
@@ -1434,45 +1428,31 @@ prepare_vm() {
     parted -s "${TARGET}" 'mklabel gpt'
     parted -s "${TARGET}" 'mkpart ESP fat32 1MiB 101MiB'
     parted -s "${TARGET}" 'set 1 boot on'
-    parted -s "${TARGET}" 'mkpart bios_grub 101MiB 102MiB'
-    parted -s "${TARGET}" 'set 2 bios_grub on'
-    parted -s "${TARGET}" 'mkpart primary ext4 102MiB 100%'
-
-  else
-    # arm64 support largely only exists for GPT
-    if [ "$ARCH" = 'arm64' ]; then
-      einfo "Setting up GPT partitions for arm64"
-      parted -s "${TARGET}" 'mklabel gpt'
-      parted -s "${TARGET}" 'mkpart ESP fat32 1MiB 10MiB'
-      parted -s "${TARGET}" 'set 1 boot on'
-      parted -s "${TARGET}" 'mkpart LINUX ext4 10MiB 100%'
+    if [ "$ARCH" = 'arm64' ] || [ "$ARCH" = 'i386' ]; then
+      # No need for a bios_grub parttion on ARM64 or i386
+      parted -s "${TARGET}" 'mkpart primary ext4 101MiB 100%'
     else
-      parted -s "${TARGET}" 'mklabel msdos'
-      if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
-        einfo "Adjusting disk signature to a fixed (non-random) value"
-        MBRTMPFILE=$(mktemp)
-        dd if="${TARGET}" of="${MBRTMPFILE}" bs=512 count=1
-        echo -en "\\x41\\x41\\x41\\x41" | dd of="${MBRTMPFILE}" conv=notrunc seek=440 bs=1
-        dd if="${MBRTMPFILE}" of="${TARGET}" conv=notrunc
-      fi
-      parted -s "${TARGET}" 'mkpart primary ext4 4MiB 100%'
-      parted -s "${TARGET}" 'set 1 boot on'
+      parted -s "${TARGET}" 'mkpart bios_grub 101MiB 102MiB'
+      parted -s "${TARGET}" 'set 2 bios_grub on'
+      parted -s "${TARGET}" 'mkpart primary ext4 102MiB 100%'
     fi
+  else
+    parted -s "${TARGET}" 'mklabel msdos'
+    if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
+      einfo "Adjusting disk signature to a fixed (non-random) value"
+      MBRTMPFILE=$(mktemp)
+      dd if="${TARGET}" of="${MBRTMPFILE}" bs=512 count=1
+      echo -en "\\x41\\x41\\x41\\x41" | dd of="${MBRTMPFILE}" conv=notrunc seek=440 bs=1
+      dd if="${MBRTMPFILE}" of="${TARGET}" conv=notrunc
+    fi
+    parted -s "${TARGET}" 'mkpart primary ext4 4MiB 100%'
+    parted -s "${TARGET}" 'set 1 boot on'
   fi
 
-  DEVINFO=$(kpartx -asv "$TARGET") # e.g. 'add map loop0p1 (254:5): 0 20477 linear 7:0 3' - will be multi-line for arm64
+  DEVINFO=$(kpartx -asv "$TARGET") # e.g. 'add map loop0p1 (254:5): 0 20477 linear 7:0 3' - will be multi-line for EFI VMs
   if [ -z "${DEVINFO}" ] ; then
     eerror "Error setting up loopback device."
     bailout 1
-  fi
-
-  # if we're building for arm64, we operate on the first line of $DEVINFO which is the EFI partition
-  if [ "$ARCH" = 'arm64' ]; then
-    LOOP_PART="${DEVINFO##add map }" # 'loop0p1 (254:5): 0 20477 linear 7:0 3'
-    LOOP_PART="${LOOP_PART// */}"    # 'loop0p1'
-    LOOP_DISK="${LOOP_PART%p*}"      # 'loop0'
-    export ARM_EFI_TARGET="/dev/mapper/$LOOP_PART"
-    DEVINFO=${DEVINFO##*$'\n'} # now set $DEVINFO to the last line which is the OS partition
   fi
 
   # hopefully this always works as expected
@@ -1480,7 +1460,11 @@ prepare_vm() {
   LOOP_PART="${LOOP_PART// */}"    # 'loop0p1'
   if [ -n "$VMEFI" ]; then
     export EFI_TARGET="/dev/mapper/$LOOP_PART" # '/dev/mapper/loop0p1'
-    LOOP_PART="${LOOP_PART%p1}p3"
+    if [ "$ARCH" = 'arm64' ] || [ "$ARCH" = 'i386' ]; then
+      LOOP_PART="${LOOP_PART%p1}p2"
+    else
+      LOOP_PART="${LOOP_PART%p1}p3"
+    fi
   fi
   LOOP_DISK="${LOOP_PART%p*}"      # 'loop0'
   export TARGET="/dev/mapper/$LOOP_PART" # '/dev/mapper/loop0p1'
@@ -1507,96 +1491,94 @@ grub_install() {
     bailout 1
   fi
 
-  if [ -n "${ARM_EFI_TARGET}" ]; then
-    mkdir -p "${MNTPOINT}"/boot/efi
-    if ! mount "${ARM_EFI_TARGET}" "${MNTPOINT}"/boot/efi ; then
-      eerror "Error: Mounting ${ARM_EFI_TARGET} failed, can not continue."
-      bailout 1
-    fi
-  fi
-
   mount -t proc none "${MNTPOINT}"/proc
   mount -t sysfs none "${MNTPOINT}"/sys
   mount -t devtmpfs udev "${MNTPOINT}"/dev
   mount -t devpts devpts "${MNTPOINT}"/dev/pts
 
-  if [ -n "$ARM_EFI_TARGET" ]; then
-    einfo "Installing Grub as bootloader into EFI."
-
-    # shellcheck disable=SC2086
-    clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-arm64 grub-efi-arm64-signed
-
-    clean_chroot "${MNTPOINT}" grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=debian --recheck --no-nvram --removable
   # Has chroot-script installed GRUB to MBR using grub-install (successfully), already?
   # chroot-script skips installation for unset ${GRUB}
-  elif [[ -z "${GRUB}" ]] || ! dd if="${GRUB}" bs=512 count=1 2>/dev/null | cat -v | grep -Fq GRUB; then
+  if [[ -z "${GRUB}" ]] || ! dd if="${GRUB}" bs=512 count=1 2>/dev/null | cat -v | grep -Fq GRUB; then
     einfo "Installing Grub as bootloader."
 
-    if ! clean_chroot "${MNTPOINT}" dpkg --list grub-pc 2>/dev/null | grep -q '^ii' ; then
-      echo "Notice: grub-pc package not present yet, installing it therefore."
-      # shellcheck disable=SC2086
-      clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-pc
+    local grub_pc_package_name=''
+
+    # ARM64 uses EFI-only, and doesn't need a GRUB package. For i386, we only
+    # install the BIOS bootloader if we're not using EFI (since grub-pc and
+    # grub-efi-ia32 can't be co-installed). For amd64, we install grub-cloud
+    # which will pull in grub-pc-bin, so we don't need to explicitly install a
+    # BIOS bootloader for it when using EFI.
+    if [ -z "$VMEFI" ]; then
+      grub_pc_package_name='grub-pc'
     fi
 
-    mkdir -p "${MNTPOINT}/boot/grub"
-    if ! [ -d "${MNTPOINT}"/usr/lib/grub/i386-pc/ ] ; then
-      eerror "Error: grub not installed inside Virtual Machine. Can not install bootloader."
-      bailout 1
+    if [ -n "${grub_pc_package_name}" ]; then
+      if ! clean_chroot "${MNTPOINT}" dpkg --list "${grub_pc_package_name}" 2>/dev/null | grep -q '^ii' ; then
+        echo "Notice: ${grub_pc_package_name} package not present yet, installing it therefore."
+        clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS "${grub_pc_package_name}"
+      fi
     fi
-    cp -a "${MNTPOINT}"/usr/lib/grub/i386-pc "${MNTPOINT}/boot/grub/"
 
     if [ -n "$VMEFI" ]; then
-
       mkdir -p "${MNTPOINT}"/boot/efi
       mount -t vfat "${EFI_TARGET}" "${MNTPOINT}"/boot/efi
+
+      efi_id="$(
+        if [ -f "${MNTPOINT}"/etc/default/grub ]; then
+          source "${MNTPOINT}"/etc/default/grub
+        fi
+        for file in "${MNTPOINT}"/etc/default/grub.d/*.cfg; do
+          if [ -f "${file}" ]; then
+            source "${file}"
+          fi
+        done
+        if [ "${GRUB_DISTRIBUTOR}" != "" ]; then
+          echo "${GRUB_DISTRIBUTOR}"
+        else
+          echo 'Debian'
+        fi
+      )"
 
       if ! clean_chroot "${MNTPOINT}" dpkg --list shim-signed 2>/dev/null | grep -q '^ii' ; then
         echo "Notice: shim-signed package not present yet, installing it therefore."
         # shellcheck disable=SC2086
-        clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS shim-signed
+        clean_chroot "${MNTPOINT}" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS shim-signed
       fi
 
-      if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+      # The EFI bootloader will automatically be installed to the proper location when the
+      # corresponding grub-efi-ARCH package is installed.
+      if [ "${ARCH}" = "arm64" ]; then
+        clean_chroot "$MNTPOINT" debconf-set-selections <<< 'grub-efi-arm64 grub2/force_efi_extra_removable boolean true'
         if ! clean_chroot "${MNTPOINT}" dpkg --list grub-efi-arm64-signed 2>/dev/null | grep -q '^ii' ; then
           echo "Notice: grub-efi-arm64-signed package not present yet, installing it therefore."
           # shellcheck disable=SC2086
-          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-arm64-bin grub-efi-arm64-signed
+          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-arm64-signed grub-efi-arm64
         fi
-        clean_chroot "$MNTPOINT" grub-install --target=arm64-efi --efi-directory=/boot/efi --uefi-secure-boot --removable "/dev/$LOOP_DISK"
-      elif [ "$(dpkg --print-architecture)" = "i386" ]; then
+        clean_chroot "$MNTPOINT" grub-install --target=arm64-efi --efi-directory=/boot/efi --uefi-secure-boot --bootloader-id="${efi_id}" --force-extra-removable "/dev/$LOOP_DISK"
+      elif [ "${ARCH}" = "i386" ]; then
+        clean_chroot "$MNTPOINT" debconf-set-selections <<< 'grub-efi-ia32 grub2/force_efi_extra_removable boolean true'
         if ! clean_chroot "${MNTPOINT}" dpkg --list grub-efi-ia32-signed 2>/dev/null | grep -q '^ii' ; then
           echo "Notice: grub-efi-ia32-signed package not present yet, installing it therefore."
           # shellcheck disable=SC2086
-          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-ia32-bin grub-efi-ia32-signed
+          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-ia32-signed grub-efi-ia32
         fi
-        clean_chroot "$MNTPOINT" grub-install --target=i386-efi --efi-directory=/boot/efi --uefi-secure-boot --removable "/dev/$LOOP_DISK"
-        clean_chroot "$MNTPOINT" grub-install --target=i386-pc "/dev/$LOOP_DISK"
+        clean_chroot "$MNTPOINT" grub-install --target=i386-efi --efi-directory=/boot/efi --uefi-secure-boot --bootloader-id="${efi_id}" --force-extra-removable "/dev/$LOOP_DISK"
       else
-        if ! clean_chroot "${MNTPOINT}" dpkg --list grub-efi-amd64-signed 2>/dev/null | grep -q '^ii' ; then
-          echo "Notice: grub-efi-amd64-signed package not present yet, installing it therefore."
+        if ! clean_chroot "${MNTPOINT}" dpkg --list grub-cloud-amd64 2>/dev/null | grep -q '^ii' ; then
+          echo "Notice: grub-cloud-amd64 package not present yet, installing it therefore."
           # shellcheck disable=SC2086
-          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-amd64-bin grub-efi-amd64-signed
+          clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-cloud-amd64
         fi
-        clean_chroot "$MNTPOINT" grub-install --target=x86_64-efi --efi-directory=/boot/efi --uefi-secure-boot --removable "/dev/$LOOP_DISK"
+        # grub-cloud pulls in all the needed deps. We don't use it to install
+        # GRUB initially, but we do need it to update GRUB, so we have to
+        # touch /etc/grub.d/enable_cloud.
+        mkdir -p "${MNTPOINT}"/etc/grub.d
+        touch "${MNTPOINT}"/etc/grub.d/enable_cloud
+        clean_chroot "$MNTPOINT" grub-install --target=x86_64-efi --efi-directory=/boot/efi --uefi-secure-boot --bootloader-id="${efi_id}" --force-extra-removable "/dev/$LOOP_DISK"
         clean_chroot "$MNTPOINT" grub-install --target=i386-pc "/dev/$LOOP_DISK"
       fi
     else
-      dd if="${MNTPOINT}/usr/lib/grub/i386-pc/boot.img" of="${ORIG_TARGET}" conv=notrunc bs=440 count=1
-      case "${_opt_filesystem}" in
-        f2fs)
-          clean_chroot "${MNTPOINT}" grub-mkimage -O i386-pc -p "(hd0,msdos1)/boot/grub" -o /tmp/core.img biosdisk part_msdos f2fs
-          ;;
-        xfs)
-          clean_chroot "${MNTPOINT}" grub-mkimage -O i386-pc -p "(hd0,msdos1)/boot/grub" -o /tmp/core.img biosdisk part_msdos xfs
-          ;;
-        # NOTE - we might need to distinguish between further filesystems
-        *)
-          clean_chroot "${MNTPOINT}" grub-mkimage -O i386-pc -p "(hd0,msdos1)/boot/grub" -o /tmp/core.img biosdisk part_msdos ext2
-          ;;
-      esac
-
-      dd if="${MNTPOINT}/tmp/core.img" of="${ORIG_TARGET}" conv=notrunc seek=1
-      rm -f "${MNTPOINT}/tmp/core.img"
+      clean_chroot "$MNTPOINT" grub-install --target=i386-pc "/dev/$LOOP_DISK"
     fi
   fi
 
@@ -1620,9 +1602,6 @@ grub_install() {
   if grep -q '^GRUB_DISABLE_LINUX_UUID=.*true' "${MNTPOINT}"/etc/default/grub 2>/dev/null ; then
     ewarn "GRUB_DISABLE_LINUX_UUID is set to true in /etc/default/grub, not adjusting root= in grub.cfg."
     ewarn "Please note that your system might NOT be able to properly boot."
-  elif [ -z "$ARM_EFI_TARGET" ]; then
-    einfo "Adjusting grub.cfg for successful boot sequence."
-    sed -i "s;root=[^ ]\\+;root=UUID=$TARGET_UUID;" "${MNTPOINT}"/boot/grub/grub.cfg
   fi
 
   # workaround for Debian bug #918590 with lvm + udev:


### PR DESCRIPTION
Fixes https://github.com/grml/grml-debootstrap/issues/297. Quick summary of changes:

* On all EFI-related `grub-install` calls, `--bootloader-id=debian` and `--force-extra-removable` are used. This ensures the bootloader is installed both to the distro-specific path (`/boot/efi/EFI/debian`) and to the removable media path. `--removable` is removed from these calls as it is no longer needed and in fact prevents the normal bootloader location from being installed to. Its job is done by `--force-extra-removable` now.
* If `--vmefi` is enabled, `grub-pc-bin` is installed rather than `grub-pc`, allowing the BIOS bootloader to be *installed* but not allowing it to be automatically updated. This is to allow installing `grub-efi-ARCH`, which allows automatically updating the EFI bootloader. (Sadly the two cannot be installed at the same time, which is why this change is necessary. If they could be installed at the same time, that would be best, but Debian isn't capable of that at the moment.)
* `grub-efi-ARCH` is installed along with `grub-efi-ARCH-signed`.
* A debconf option is set to ensure that when the EFI bootloader is updated, the update is installed to both the normal and removable media paths. This option, `grub2/force_efi_extra_removable`, is documented at https://wiki.debian.org/UEFI#Force_grub-efi_installation_to_the_removable_media_path.
* I also cleaned up a trailing whitespace and a seemingly out-of-place newline while I was right here.