### PR TITLE
Update /etc/timezone only if it exists

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -471,9 +471,12 @@ timezone() {
     echo "Adjusting /etc/localtime"
     ln -sf "/usr/share/zoneinfo/$TIMEZONE" /etc/localtime
 
-    echo "Setting /etc/timezone to $TIMEZONE"
-    printf '%s\n' "$TIMEZONE"  > /etc/timezone
-
+    if [ -e /etc/timezone ] ; then
+      # not necessary for trixie or newer, see tzdata 2024b-6 changelog.
+      # https://salsa.debian.org/glibc-team/tzdata/-/commit/c071fbc167ad306394b576879d515e6ecbe5a734
+      echo "Setting /etc/timezone to $TIMEZONE"
+      printf '%s\n' "$TIMEZONE"  > /etc/timezone
+    fi
   fi
 }
 # }}}

--- a/config
+++ b/config
@@ -192,7 +192,7 @@
 # Default: 'en_US:en'
 # DEFAULT_LANGUAGE='en_US:en'
 
-# Use /usr/share/zoneinfo/$TIMEZONE for /etc/localtime + set /etc/timezone.
+# Use /usr/share/zoneinfo/$TIMEZONE for /etc/localtime.
 # Default: 'Europe/Vienna'
 # TIMEZONE='Europe/Vienna'
 

--- a/tests/goss.yaml
+++ b/tests/goss.yaml
@@ -3,9 +3,6 @@ process:
     running: true
 
 file:
-  /etc/timezone:
-    exists: true
-    contains: ["Europe/Vienna"]
   /etc/localtime:
     filetype: symlink
     exists: true


### PR DESCRIPTION
tzdata 2024b-6 stops creating /etc/timezone, so we should not create it either.

https://salsa.debian.org/glibc-team/tzdata/-/commit/c071fbc167ad306394b576879d515e6ecbe5a734