### PR TITLE
CI: test on arm hosts

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -58,13 +58,21 @@ jobs:
         - bullseye
         - buster
 
+        runner:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+
         exclude:
-          # debootstrap in bullseye is too old.
-          - host_release: bullseye
-            release: trixie
+          # restrict arm tests to bookworm and newer, mostly to save time
+          - runner: ubuntu-24.04-arm
+            host_release: bullseye
+          - runner: ubuntu-24.04-arm
+            release: bullseye
+          - runner: ubuntu-24.04-arm
+            release: buster
 
     # We want a working shell, qemu, python and docker. Specific version should not matter (much).
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v4
@@ -93,7 +101,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always() && (steps.build_vm_and_test_test.outcome == 'failure')
       with:
-        name: vm-image-${{matrix.host_release}}-${{matrix.release}}
+        name: vm-image-${{matrix.host_release}}-${{matrix.release}}-${{matrix.runner}}
         if-no-files-found: error
         path: qemu.img
         retention-days: 5
@@ -102,6 +110,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: vm-results-${{matrix.host_release}}-${{matrix.release}}
+        name: vm-results-${{matrix.host_release}}-${{matrix.release}}-${{matrix.runner}}
         if-no-files-found: error
         path: tests/results/

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1522,6 +1522,9 @@ grub_install() {
   if [ -n "$ARM_EFI_TARGET" ]; then
     einfo "Installing Grub as bootloader into EFI."
 
+    # shellcheck disable=SC2086
+    clean_chroot "$MNTPOINT" DEBIAN_FRONTEND=$DEBIAN_FRONTEND apt-get -y --no-install-recommends install $DPKG_OPTIONS grub-efi-arm64 grub-efi-arm64-signed
+
     clean_chroot "${MNTPOINT}" grub-install --target=arm64-efi --efi-directory=/boot/efi --bootloader-id=debian --recheck --no-nvram --removable
   # Has chroot-script installed GRUB to MBR using grub-install (successfully), already?
   # chroot-script skips installation for unset ${GRUB}

--- a/tests/build-vm-and-test.sh
+++ b/tests/build-vm-and-test.sh
@@ -33,7 +33,13 @@ fi
 
 if [ "$1" == "setup" ]; then
   sudo apt-get update
-  sudo apt-get -qq -y install curl qemu-system-x86 kpartx python3-pexpect python3-serial
+  sudo apt-get -qq -y install curl kpartx python3-pexpect python3-serial
+  DPKG_ARCHITECTURE=$(dpkg --print-architecture)
+  if [ "${DPKG_ARCHITECTURE}" = "amd64" ]; then
+    sudo apt-get -qq -y install qemu-system qemu-system-gui ovmf seabios
+  elif [ "${DPKG_ARCHITECTURE}" = "arm64" ]; then
+    sudo apt-get -qq -y install qemu-system qemu-system-gui qemu-efi-aarch64
+  fi
   # vncsnapshot might not be available, though we don't want to abort execution then
   sudo apt-get -qq -y install vncsnapshot || true
   [ -x ./tests/goss ] || curl -fsSL https://goss.rocks/install | GOSS_DST="$(pwd)/tests" sh


### PR DESCRIPTION
Uses the preview runners, as announced in https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Fixes one copy of the grub-install cases, broken by PR #316, identified by the new CI runs.