### PR TITLE
Drop --iso support

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -40,14 +40,8 @@ bash -n /etc/debootstrap/variables
 # use aptitude only if it's available
 if [ -x /usr/bin/aptitude ] ; then
    APTUPDATE="aptitude update $DPKG_OPTIONS"
-   # Debian ISOs do not contain signed Release files
-   if [ -n "$ISO" ] ; then
-      APTINSTALL="aptitude -y --allow-untrusted --without-recommends install $DPKG_OPTIONS"
-      APTUPGRADE="aptitude -y --allow-untrusted safe-upgrade $DPKG_OPTIONS"
-   else
-      APTINSTALL="aptitude -y --without-recommends install $DPKG_OPTIONS"
-      APTUPGRADE="aptitude -y safe-upgrade $DPKG_OPTIONS"
-   fi
+   APTINSTALL="aptitude -y --without-recommends install $DPKG_OPTIONS"
+   APTUPGRADE="aptitude -y safe-upgrade $DPKG_OPTIONS"
 else
    APTINSTALL="apt-get -y --no-install-recommends install $DPKG_OPTIONS"
    APTUPDATE="apt-get update $DPKG_OPTIONS"
@@ -110,19 +104,9 @@ chrootmirror() {
   fi
   echo "Using repository components $COMPONENTS"
 
-  if [ -n "$ISO" ] ; then
-    echo "Adjusting sources.list for ISO (${ISO})."
-    echo "deb $ISO $RELEASE $COMPONENTS" > /etc/apt/sources.list
-
-    if [ -n "$MIRROR" ] ; then
-      echo "Adding mirror entry (${MIRROR}) to sources.list."
-      echo "deb $MIRROR $RELEASE $COMPONENTS" >> /etc/apt/sources.list
-    fi
-  else
-    if [ -n "$MIRROR" ] ; then
-      echo "Adjusting sources.list for mirror (${MIRROR})."
-      echo "deb $MIRROR $RELEASE $COMPONENTS" > /etc/apt/sources.list
-    fi
+  if [ -n "$MIRROR" ] ; then
+    echo "Adjusting sources.list for mirror (${MIRROR})."
+    echo "deb $MIRROR $RELEASE $COMPONENTS" > /etc/apt/sources.list
   fi
 
   # add security.debian.org:
@@ -149,18 +133,12 @@ remove_chrootmirror() {
     return
   fi
 
-  if [ -n "$ISO" ] ; then
-    echo "Removing ISO (${ISO}) from sources.list."
-    TMP_ISO="${ISO//\//\\\/}"
-    sed -i "/deb $TMP_ISO $RELEASE $COMPONENTS/ D" /etc/apt/sources.list
-  else
-    if [ -n "$MIRROR" ] && echo "$MIRROR" | grep -q 'file:' ; then
-      echo "Removing local mirror (${MIRROR}) from sources.list."
-      TMP_MIRROR="${MIRROR//\//\\\/}"
-      sed -i "/deb $TMP_MIRROR $RELEASE $COMPONENTS/ D" /etc/apt/sources.list
-      echo "Adding fallback mirror entry (${FALLBACK_MIRROR}) to sources.list instead."
-      echo "deb $FALLBACK_MIRROR $RELEASE $COMPONENTS" >> /etc/apt/sources.list
-    fi
+  if [ -n "$MIRROR" ] && echo "$MIRROR" | grep -q 'file:' ; then
+    echo "Removing local mirror (${MIRROR}) from sources.list."
+    TMP_MIRROR="${MIRROR//\//\\\/}"
+    sed -i "/deb $TMP_MIRROR $RELEASE $COMPONENTS/ D" /etc/apt/sources.list
+    echo "Adding fallback mirror entry (${FALLBACK_MIRROR}) to sources.list instead."
+    echo "deb $FALLBACK_MIRROR $RELEASE $COMPONENTS" >> /etc/apt/sources.list
   fi
 }
 # }}}

--- a/config
+++ b/config
@@ -46,12 +46,6 @@
 # Usage example:
 # MIRROR='ftp://ftp.de.debian.org/debian'
 
-# Debian Install CD path:
-# If you have a Debian CD (or mounted ISO), core packages will be
-# installed from the CD instead of from the network.
-# Default: no default.
-# ISO='file:/mnt/iso/debian/'
-
 # If /etc/apt/sources.list should NOT be build on the fly, this
 # options allows providing a separate apt sources.list file via
 # /etc/debootstrap/etc/apt/sources.list

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -93,8 +93,6 @@ Usage: $PN [options]
 Bootstrap options:
 
   -m, --mirror <URL>     Mirror which should be used for apt-get/aptitude.
-  -i, --iso <mnt>        Mountpoint where a Debian ISO is mounted to, for use
-                         instead of fetching packages from a mirror.
   -r, --release <name>   Release of new Debian system (default: bullseye).
   -t, --target <target>  Target partition (/dev/...) or directory where the
                          system should be installed to.
@@ -304,10 +302,6 @@ cleanup() {
         umount "$MNTPOINT"/$ARG >/dev/null 2>&1 || true
       done
 
-      if [ -n "$ISODIR" ] ; then
-        try_umount 3 "$MNTPOINT/$ISODIR" >/dev/null 2>&1 || true
-      fi
-
       if [ -n "$DIRECTORY" ] ; then
         einfo "Not unmounting $MNTPOINT as you requested me to install into a directory of your own choice."
       else
@@ -391,9 +385,6 @@ while :; do
   # == Bootstrap options
   --mirror|-m)         # Mirror which should be used for apt-get/aptitude
     shift; _opt_mirror="$1"
-    ;;
-  --iso|-i)            # Mountpoint where a Debian ISO is mounted to
-    shift; _opt_iso="$1"
     ;;
   --release|-r)        # Release of new Debian system
     shift; _opt_release="$1"
@@ -572,7 +563,6 @@ done
 # }}}
 
 [ "$_opt_mirror" ]              && MIRROR=$_opt_mirror
-[ "$_opt_iso" ]                 && ISO=$_opt_iso
 [ "$_opt_release" ]             && RELEASE=$_opt_release
 [ "$_opt_target" ]              && TARGET=$_opt_target
 [ "$_opt_vm" ]                  && VIRTUAL=1
@@ -638,12 +628,6 @@ fi
 
 if [ "${_opt_sshcopyid}" ] && [ "${_opt_sshcopyauth}" ] ; then
   eerror "The --sshcopyid option is incompatible with --sshcopyauth, please drop either of them from your command line."
-  bailout 1
-fi
-
-if [ -n "$ISO" ] && [[ "$DEBOOTSTRAP" =~ mmdebstrap$ ]] ; then
-  eerror "The ISO option is incompatible with usage of mmdebstrap for bootstrapping."
-  eerror "Either drop the --iso ... option or use plain debootstrap instead."
   bailout 1
 fi
 
@@ -864,26 +848,10 @@ prompt_for_password()
 # ask for Debian mirror {{{
 prompt_for_mirror()
 {
-  [ -n "$ISO" ] && DEFAULT_MIRROR='local' || DEFAULT_MIRROR='net'
-
-  CHOOSE_MIRROR=$(dialog --stdout --title "$PN" --default-item "$DEFAULT_MIRROR" \
-          --menu "Where do you want to install from?" 0 0 0 \
-            net   "install via network (downloading from mirror)" \
-            local "install from local directory/mirror"
-          )
-
-  if [ "$CHOOSE_MIRROR" = 'net' ] ; then
-     [ -n "$MIRROR" ] || MIRROR='http://deb.debian.org/debian'
-     MIRROR="$(dialog --stdout --title "${PN}" --inputbox \
-               "Please enter Debian mirror you would like to use for installing packages." \
-               0 0 "$MIRROR")" || bailout
-
-  else # CHOOSE_MIRROR == local
-     [ -n "$ISO" ] || ISO='/mnt/mirror'
-     ISO="$(dialog --stdout --title "${PN}" --inputbox \
-               "Please enter directory name you would like to use for installing packages." \
-               0 0 "$ISO")" || bailout
-  fi
+  [ -n "$MIRROR" ] || MIRROR='http://deb.debian.org/debian'
+  MIRROR="$(dialog --stdout --title "${PN}" --inputbox \
+            "Please enter Debian mirror you would like to use for installing packages." \
+            0 0 "$MIRROR")" || bailout
 }
 # }}}
 
@@ -1044,8 +1012,6 @@ if [ -n "$INTERACTIVE" ] ; then
    Using hostname:  $HOSTNAME"
    [ -n "$MIRROR" ]  && INFOTEXT="$INFOTEXT
    Using mirror:    $MIRROR"
-   [ -n "$ISO" ]  && INFOTEXT="$INFOTEXT
-   Using ISO:       $ISO"
    [ -n "$ARCH" ]  && INFOTEXT="$INFOTEXT
    Using arch:      $ARCH"
    [ -n "$CONFFILES" ] && INFOTEXT="$INFOTEXT
@@ -1077,7 +1043,6 @@ else # if not running automatic installation display configuration and prompt fo
    [ -n "$RELEASE" ]   && echo "   Using release:   $RELEASE"
    [ -n "$HOSTNAME" ]  && echo "   Using hostname:  $HOSTNAME"
    [ -n "$MIRROR" ]    && echo "   Using mirror:    $MIRROR"
-   [ -n "$ISO" ]       && echo "   Using ISO:       $ISO"
    [ -n "$ARCH" ]      && echo "   Using arch:      $ARCH"
    [ -n "$CONFFILES" ] && echo "   Config files:    $CONFFILES"
    if [ -n "$VIRTUAL" ] ; then
@@ -1229,26 +1194,6 @@ else
       bailout 1
     fi
     set_target_directory
-fi
-# }}}
-
-# make sure we have the right syntax when using an iso image {{{
-if [ -n "$ISO" ] ; then
-   case $ISO in
-      file*) # do nothing
-      ;;
-      *)
-      ISO=file:$ISO
-      ;;
-   esac
-fi
-ISODIR=${ISO##file:}
-ISODIR=${ISODIR%%/}
-# }}}
-
-# Debian ISOs do not contain signed Release files {{{
-if [ -n "$ISO" ] ; then
-    DEBOOTSTRAP_OPT="$DEBOOTSTRAP_OPT --no-check-gpg"
 fi
 # }}}
 
@@ -1442,11 +1387,6 @@ mount_target() {
        mkdir -p "$MNTPOINT"
        mount -o rw,suid,dev "$TARGET" "$MNTPOINT"
      fi
-  fi
-  if [ -n "$ISODIR" ] ; then
-     einfo "Mounting Debian image loopback to $MNTPOINT/$ISODIR."
-     mkdir -p "$MNTPOINT/$ISODIR"
-     mount --bind "$ISODIR" "$MNTPOINT/$ISODIR"
   fi
 }
 # }}}
@@ -1724,17 +1664,10 @@ debootstrap_system() {
     eend 1 ; exit 1
   fi
 
-  if [ -n "$ISO" ] ; then
-    einfo "Running $DEBOOTSTRAP $DEBOOTSTRAP_OPT for release ${RELEASE}${ARCHINFO} using ${ISO}"
-    einfo "Executing: $DEBOOTSTRAP $ARCHCMD $DEBOOTSTRAP_OPT $RELEASE $MNTPOINT $ISO"
-    # shellcheck disable=SC2086
-    "$DEBOOTSTRAP" $ARCHCMD $DEBOOTSTRAP_OPT "$RELEASE" "$MNTPOINT" "$ISO"
-  else
-    einfo "Running $DEBOOTSTRAP $DEBOOTSTRAP_OPT for release ${RELEASE}${ARCHINFO} using ${MIRROR}"
-    einfo "Executing: $DEBOOTSTRAP $ARCHCMD $DEBOOTSTRAP_OPT $RELEASE $MNTPOINT $MIRROR"
-    # shellcheck disable=SC2086
-    "$DEBOOTSTRAP" $ARCHCMD $DEBOOTSTRAP_OPT "$RELEASE" "$MNTPOINT" "$MIRROR"
-  fi
+  einfo "Running $DEBOOTSTRAP $DEBOOTSTRAP_OPT for release ${RELEASE}${ARCHINFO} using ${MIRROR}"
+  einfo "Executing: $DEBOOTSTRAP $ARCHCMD $DEBOOTSTRAP_OPT $RELEASE $MNTPOINT $MIRROR"
+  # shellcheck disable=SC2086
+  "$DEBOOTSTRAP" $ARCHCMD $DEBOOTSTRAP_OPT "$RELEASE" "$MNTPOINT" "$MIRROR"
 }
 # }}}
 
@@ -1810,8 +1743,6 @@ preparechroot() {
   [ -n "$INITRD_GENERATOR" ]          && echo "INITRD_GENERATOR='${INITRD_GENERATOR//\'/\'\\\'\'}'"                 >> "$CHROOT_VARIABLES"
   [ -n "$INITRD_GENERATOR_OPTS" ]     && echo "INITRD_GENERATOR_OPTS='${INITRD_GENERATOR_OPTS//\'/\'\\\'\'}'"       >> "$CHROOT_VARIABLES"
   [ -n "$INSTALL_NOTES" ]             && echo "INSTALL_NOTES='${INSTALL_NOTES//\'/\'\\\'\'}'"                       >> "$CHROOT_VARIABLES"
-  [ -n "$ISODIR" ]                    && echo "ISODIR='${ISO//\'/\'\\\'\'}'"                                        >> "$CHROOT_VARIABLES"
-  [ -n "$ISO" ]                       && echo "ISO='${ISO//\'/\'\\\'\'}'"                                           >> "$CHROOT_VARIABLES"
   [ -n "$KEEP_SRC_LIST" ]             && echo "KEEP_SRC_LIST='${KEEP_SRC_LIST//\'/\'\\\'\'}'"                       >> "$CHROOT_VARIABLES"
   [ -n "$LOCALES" ]                   && echo "LOCALES='${LOCALES//\'/\'\\\'\'}'"                                   >> "$CHROOT_VARIABLES"
   [ -n "$MIRROR" ]                    && echo "MIRROR='${MIRROR//\'/\'\\\'\'}'"                                     >> "$CHROOT_VARIABLES"
@@ -2096,11 +2027,6 @@ umount_chroot() {
   # display installation notes:
   if [ -n "$INSTALL_NOTES" ] ; then
      [ -r "${MNTPOINT}/${INSTALL_NOTES}" ] && cat "${MNTPOINT}/${INSTALL_NOTES}"
-  fi
-
-  if [ -n "$ISODIR" ] ; then
-     einfo "Unmount $MNTPOINT/$ISODIR"
-     try_umount 3 "$MNTPOINT/$ISODIR"
   fi
 
   try_umount 3 "${MNTPOINT}"/run/udev

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -134,14 +134,6 @@ Options and environment variables
 
     Use specified hostname instead of the default (being $HOSTNAME or if unset 'grml').
 
-*-i*, *--iso* _/mntpoint_::
-
-    Specify mount point where you have a Debian ISO mounted loopback.
-    Using this option instead of the mirror option gives you the possibility
-    to install the base-system without network access. Make sure you
-    mounted the according Debian-ISO to the given _/mntpoint_. See section
-    'Usage examples' for a demonstration.
-
 *--keep_src_list*::
 
      Do not overwrite user provided /etc/apt/sources.list.
@@ -337,13 +329,8 @@ Use specified mirror instead of the default (http://deb.debian.org/debian) one.
   mount /dev/sda1 /mnt/sda1
   grml-debootstrap --vmfile --vmsize 3G --target /mnt/sda1/qemu.img
 
-Install default debian release (bookworm) in a Virtual Machine file with 3GB disk size (including GRUB as bootmanager in MBR of the virtual disk file):
+Install default debian release (bookworm) in a Virtual Machine file with 3GB disk size (including GRUB as bootmanager in MBR of the virtual disk file).
 
-  mount -o loop ./debian-CD-1.iso /media/cdrom
-  grml-debootstrap --target /dev/sda1 --grub /dev/sda --iso /media/cdrom
-
-Install Debian on /dev/sda1 using the loopback mounted Debian-ISO for the base-system and install bootmanager GRUB in MBR (master boot record) of /dev/sda.
-Please notice, that the chroot system requires network access for all packages which are not part of the ISO.
 
 Files
 -----


### PR DESCRIPTION
Installing using a loopback-mounted ISO as an unsigned mirror seems not very useful today.

Reference: https://github.com/grml/grml-debootstrap/issues/311