### PR TITLE
Stop installing acpi-support-base by default

### DIFF
--- a/packages
+++ b/packages
@@ -1,4 +1,3 @@
-acpi-support-base
 bridge-utils
 bzip2
 console-common


### PR DESCRIPTION
Should be taken care of by systemd and logind nowadays.