### PR TITLE
doc: merge releasetable.txt into grml-debootstrap.8.txt

### DIFF
--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -377,7 +377,15 @@ make sure that EXTRAPACKAGES is set to "yes".
 Supported Releases
 ------------------
 
-include::releasetable.txt[]
+.Current status
+[width="40%",frame="topbot",options="header"]
+|======================
+|Release  |Status
+|buster   |works[1]
+|bullseye |works
+|bookworm |works
+|sid      |works[2]
+|======================
 
 [NOTE]
 .buster release

--- a/releasetable.txt
+++ b/releasetable.txt
@@ -1,9 +1,0 @@
-.Current status
-[width="40%",frame="topbot",options="header"]
-|======================
-|Release  |Status
-|buster   |works[1]
-|bullseye |works
-|bookworm |works
-|sid      |works[2]
-|======================


### PR DESCRIPTION
Nothing seems to use releasetable.txt from any other place, so it can just be in the same file.

Useful if grml.org webpage wants to automatically render the asciidoc content.