### PR TITLE
use `LC_ALL=C` instead of `LANG=C` inside chroot

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1678,9 +1678,7 @@ debootstrap_system() {
 clean_chroot() {
   # inside the chroot system locales might not be available, so use minimum:
   local -a env_vars=(
-    "LANG=C"
     "LC_ALL=C"
-    "LANGUAGE=C"
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   )
 


### PR DESCRIPTION
no longer set redundant environment variables LANG=C and LANGUAGE=C in because already setting LC_ALL=C

https://github.com/grml/grml-debootstrap/issues/310
https://github.com/grml/grml-debootstrap/pull/313
