### PR TITLE
Drop support for Debian's "i386" port

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -308,32 +308,16 @@ get_kernel_version() {
     return 0
   fi
 
-  local KARCH
-
-  # shellcheck disable=SC2153
-  case "$ARCH" in
-    i386)
-      KARCH='686-pae'
-      ;;
-    amd64)
-      KARCH='amd64'
-      ;;
-    arm64)
-      KARCH='arm64'
-      ;;
-    *)
-      echo "Only i386, amd64 and arm64 are currently supported" >&2
-      return 1
-  esac
-
-  local KPACKAGE
-  KPACKAGE=linux-image-"${KPREFIX}${KARCH}"
-  if package_exists "$KPACKAGE"; then
-    echo "${KPREFIX}${KARCH}"
+  local kpackage
+  local ksuffix
+  ksuffix="${KPREFIX}$(dpkg --print-architecture)"
+  kpackage=linux-image-"${ksuffix}"
+  if package_exists "${kpackage}"; then
+    echo "${ksuffix}"
     return 0
   fi
 
-  echo "Expected kernel package $KPACKAGE not found" >&2
+  echo "Automatically determined kernel package named ${kpackage} not found" >&2
   return 1
 }
 

--- a/config
+++ b/config
@@ -76,7 +76,6 @@
 # COMPONENTS='main contrib non-free'
 
 # Set target architecture.
-# Only useful when installing i386 while running an amd64 kernel.
 # Default: current architecture. (From 'dpkg --print-architecture'.)
 # ARCH='amd64'
 

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -102,7 +102,7 @@ Bootstrap options:
       --nodebootstrap    Skip debootstrap, only do configuration to the target.
       --grub <device>    Target for grub installation. Usage example: /dev/sda
       --efi <device>     Target for EFI installation. Usage example: /dev/sda1
-      --arch <arch>      Set target architecture, use for installing i386 on amd64.
+      --arch <arch>      Set target architecture.
       --filesystem <fs>  Filesystem that should be used when target is a partition
                          or Virtual Machine (see --vmfile).
       --force            Do not prompt for user acknowledgement.
@@ -1127,13 +1127,10 @@ if [ -z "${ARCH:-}" ] ; then
 fi
 # }}}
 
-# It is not possible to build amd64 on i686. {{{
-CURRENT_ARCH="$(uname -m)"
-if [ "$CURRENT_ARCH" != "x86_64" ] ; then
-   if [ "$ARCH" = "amd64" ] ; then
-      eerror "It is not possible to build amd64 on $CURRENT_ARCH. Consider installing and booting the 'linux-image-amd64' kernel or using '--arch i386' instead."
-      bailout 1
-   fi
+# Only support certain architectures. {{{
+if [[ "$ARCH" != "amd64" ]] && [[ "$ARCH" != "arm64" ]] ; then
+  eerror "Unsupported architecture: ${ARCH}. Only amd64, arm64 are supported by grml-debootstrap."
+  bailout 1
 fi
 # }}}
 

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -34,9 +34,8 @@ Options and environment variables
 *--arch* _architecture_::
 
     Set target architecture you want to install. Defaults to the architecture
-    you are currently running. If you're running an amd64 kernel and want to
-    deploy an i386 system use this option. Note: deploying amd64 from an i386
-    kernel does *not* work. Example: "_--arch i386_"
+    you are currently running.
+    Example: "_--arch amd64_"
 
 *--backportrepos*::
 


### PR DESCRIPTION
Debian stops supporting the "i386" port with trixie, and we have not been testing it for a very long time. Also simplifies some code here.

Closes: grml/grml-debootstrap#321