### PR TITLE
packages: replace dbus with libpam-systemd

### DIFF
--- a/packages
+++ b/packages
@@ -3,11 +3,11 @@ bzip2
 console-common
 console-data
 cryptsetup
-dbus
 file
 ifenslave
 isc-dhcp-client
 less
+libpam-systemd
 locales
 lsb-release
 lsof


### PR DESCRIPTION
libpam-systemd is what enables most of the systemd features we previously installed dbus before. We still get dbus as a dependency of libpam-systemd.

Fixes: 86f83aa4b5047fafa74ef003d2da70bf1eeb50a7