### PR TITLE
Cleanup old Depends:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Vcs-Browser: https://github.com/grml/grml-debootstrap
 Package: grml-debootstrap
 Architecture: all
 Depends:
- bash (>= 4.3-11+deb8u2),
  debian-archive-keyring,
  mmdebstrap,
  dosfstools,

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Depends:
  mmdebstrap,
  dosfstools,
  e2fsprogs,
- fdisk | util-linux (<< 2.29.2-3~),
+ fdisk,
  gawk,
  kmod,
  ${misc:Depends},


### PR DESCRIPTION
These Depends: entries are not necessary anymore since buster.

Found in https://qa.debian.org/debcheck.php?dist=testing&package=grml-debootstrap
