### PR TITLE
efi_support: drop BIOS-mode info

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -977,11 +977,6 @@ format_efi_partition() {
 # check for EFI support or try to enable it {{{
 efi_support() {
   local efivars_loaded=false
-  # this is for kernels versions before v3.10, which didn't provide efivarfs yet
-  if modprobe efivars &>/dev/null ; then
-    efivars_loaded=true
-  fi
-  # kernel versions v3.10 and newer usually provide efivarfs
   if modprobe efivarfs &>/dev/null ; then
     efivars_loaded=true
   fi

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -976,21 +976,17 @@ format_efi_partition() {
 
 # check for EFI support or try to enable it {{{
 efi_support() {
-  local efivars_loaded=false
-  if modprobe efivarfs &>/dev/null ; then
-    efivars_loaded=true
-  fi
+  # Absence of an EFI runtime does not prevent loading efivarfs since commit
+  # 301de9a2055357375a4e1053d9df0f8f3467ff00 which landed in Linux v6.3.
+  # Unconditionally load it, in case nothing else attempted it.
+  modprobe efivarfs &>/dev/null || true
 
   if [ -d /sys/firmware/efi ] ; then
     einfo "EFI support detected."
     return 0
   fi
 
-  if ! [ -d /sys/firmware/efi ] && [ "${efivars_loaded:-}" = "true" ] ; then
-    einfo "EFI support detected, but system seems to be running in BIOS mode."
-  fi
-
-  # The user may have a legitimate reason to do an EFI installation on a BIOS
+  # The user may have a legitimate reason to do an EFI installation on a non-EFI
   # system (for instance if doing a hybrid-bootable installation), so don't
   # return 1 here.
 }


### PR DESCRIPTION
Absence of an EFI runtime does not prevent loading efivarfs since commit
torvalds/linux@301de9a2055357375a4e1053d9df0f8f3467ff00 which landed in Linux v6.3.

Thus our check code cannot work anymore, and the message is at best misleading.
