### PR TITLE
Verify that GRUB configuration points to valid block device

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1145,6 +1145,12 @@ Please use specific codenames such as bookworm or trixie."
 fi
 # }}}
 
+# Verify that provided GRUB device actually exists{{{
+if [ -n "${GRUB}" ] && ! [ -b "${GRUB}" ] ;  then
+  eerror "GRUB target '${GRUB}' doesn't look like a supported block device."
+  bailout 1
+fi
+# }}}
 checkconfiguration
 
 # finally make sure at least $TARGET is set [the partition for the new system] {{{


### PR DESCRIPTION
When invoking grml-debootstrap with `--grub /dev/`, it fails with:

```
| Installing for i386-pc platform.
| grub-install: error: cannot read `/dev': Is a directory. | Error: failed to execute 'grub-install --no-floppy --target=i386-pc /dev/'.
```

This is caused by our own invocation of `grub-install --no-floppy --target=i386-pc "${device}`, while we're also setting GRUB's debconf to `grub-cloud-amd64/install_devices: /dev/`.

Furthermore, when invoking grml-debootstrap with `--grub /dev/fail`, it fails hard - but non-obvious - within invocation of efibootmgr:

```
| Invoking efibootmgr
| BootCurrent: 0003
| Timeout: 1 seconds
| [...]
| MirrorStatus: Platform does not support address range mirror | DesiredMirroredPercentageAbove4G: 0.00
| DesiredMirrorMemoryBelow4GB: false
| Unexpected non-zero exit code 1 in /bin/chroot-script /bin/chroot-script /bin/chroot-script at line 725 853 0 detected!
```

Avoid any such misusage, by validating that the GRUB device at least points to a valid block device.

See https://github.com/grml/grml-debootstrap/issues/339