### PR TITLE
Remove kpartx workaround

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -326,11 +326,6 @@ cleanup() {
   if [ -n "${ORIG_TARGET}" ] ; then
     einfo "Removing loopback mount of file ${ORIG_TARGET}."
     kpartx -d "${ORIG_TARGET}" || eend $?
-    # Workaround for a bug in kpartx which doesn't clean up properly,
-    # see Debian Bug #891077 and Github-PR grml/grml-debootstrap#112
-    if dmsetup ls | grep -q "^${LOOP_PART} "; then
-      kpartx -d "/dev/${LOOP_DISK}" >/dev/null || eend $?
-    fi
   fi
 }
 
@@ -1519,11 +1514,6 @@ umount_target() {
 
   try_umount 3 "${MNTPOINT}"
   kpartx -d "${ORIG_TARGET}" >/dev/null
-  # Workaround for a bug in kpartx which doesn't clean up properly,
-  # see Debian Bug #891077 and Github-PR grml/grml-debootstrap#112
-  if dmsetup ls | grep -q "^${LOOP_PART} "; then
-    kpartx -d "/dev/${LOOP_DISK}" >/dev/null
-  fi
 }
 # }}}
 


### PR DESCRIPTION
Debian bug #891077 was fixed a long time ago, remove the workarounds.

See grml/grml-debootstrap#344.