### PR TITLE
Drop support for Debian v10 / buster

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -56,7 +56,6 @@ jobs:
         - trixie
         - bookworm
         - bullseye
-        - buster
 
         runner:
         - ubuntu-latest
@@ -68,8 +67,6 @@ jobs:
             host_release: bullseye
           - runner: ubuntu-24.04-arm
             release: bullseye
-          - runner: ubuntu-24.04-arm
-            release: buster
 
     # We want a working shell, qemu, python and docker. Specific version should not matter (much).
     runs-on: ${{ matrix.runner }}

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	rm -rf grml-debootstrap.8.html grml-debootstrap.8.xml grml-debootstrap.8 html-stamp man-stamp packer/local_dir/
 
 testrun:
-	cd ./packer && $(MAKE) compile && $(MAKE) buster
+	cd ./packer && $(MAKE) && $(MAKE) trixie
 
 vagrant:
 	vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "packer/debian64_buster.box"
+  config.vm.box = "packer/debian64_trixie.box"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/chroot-script
+++ b/chroot-script
@@ -80,7 +80,7 @@ askpass() {
 # mark existing packages as automatically installed {{{
 markauto() {
   case "$RELEASE" in
-    buster|bullseye)
+    bullseye)
       # apt-mark is unavailable or does not support all used patterns.
       return
       ;;
@@ -112,10 +112,6 @@ chrootmirror() {
   # add security.debian.org:
   case "$RELEASE" in
     unstable|sid) ;;  # no security pool available
-    buster)
-      echo "Adding security.debian.org to sources.list."
-      echo "deb http://security.debian.org ${RELEASE}/updates $COMPONENTS" >> /etc/apt/sources.list
-      ;;
     *)
       # bullseye and newer releases use a different repository layout, see
       # https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html

--- a/config
+++ b/config
@@ -67,9 +67,9 @@
 # BACKPORTREPOS='yes'
 
 # Debian release that should be installed.
-# Supported values: buster, bullseye, sid
-# Default: 'bullseye'
-# RELEASE='bullseye'
+# Supported values: bullseye, bookworm, trixie, sid
+# Default: 'trixie'
+# RELEASE='trixie'
 
 # Define components that should be used within sources.list.
 # Default: 'main'

--- a/docker/test_dirinstall.bats
+++ b/docker/test_dirinstall.bats
@@ -20,5 +20,5 @@ mountpoint="/srv/debian"
 @test "debian_version exists and is valid version" {
   run cat "${mountpoint}/etc/debian_version"
   [ "$status" -eq 0 ]
-  [[ "$output" == [0-9].[0-9]* ]] || [[ "$output" == 'buster/sid' ]]
+  [[ "$output" == [0-9].[0-9]* ]] || [[ "$output" == 'trixie/sid' ]]
 }

--- a/docker/test_vminstall.bats
+++ b/docker/test_vminstall.bats
@@ -35,5 +35,5 @@ teardown() {
 @test "debian_version exists and is valid version" {
   run cat "${mountpath}/etc/debian_version"
   [ "$status" -eq 0 ]
-  [[ "$output" == [0-9].[0-9]* ]] || [[ "$output" == 'buster/sid' ]]
+  [[ "$output" == [0-9].[0-9]* ]] || [[ "$output" == 'trixe/sid' ]]
 }

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -605,7 +605,7 @@ done
 [ "$_opt_contrib" ]             && COMPONENTS="$COMPONENTS contrib"
 
 case "${RELEASE}" in
-  buster|bullseye)
+  bullseye)
     [ "$_opt_non_free" ] && COMPONENTS="$COMPONENTS non-free"
     ;;
   *)
@@ -819,8 +819,7 @@ prompt_for_release()
   local default_value="$RELEASE"
   RELEASE="$(dialog --stdout --title "${PN}" --default-item "$default_value" --menu \
             "Please enter the Debian release you would like to use for installation:" \
-            0 50 8 \
-            buster   Debian/10 \
+            0 50 0 \
             bullseye Debian/11 \
             bookworm Debian/12 \
             trixie   Debian/13 \

--- a/grml-debootstrap.8.txt
+++ b/grml-debootstrap.8.txt
@@ -210,7 +210,7 @@ Options and environment variables
 *-r*, *--release* _releasename_::
 
     Specify release of new Debian system. Supported releases names:
-    buster, bullseye, bookworm, trixie and sid.
+    bullseye, bookworm, trixie and sid.
     Corresponding with configuration variable RELEASE. Default release: trixie
 
 *--remove-configs*::
@@ -292,9 +292,9 @@ Usage examples
 
 Install default Debian release (trixie) on /dev/sda1 and install bootmanager GRUB in MBR (master boot record) of /dev/sda.
 
-  grml-debootstrap --release buster --target /dev/sda1 --grub /dev/sda --hostname debian01 --password changeme
+  grml-debootstrap --release bookworm --target /dev/sda1 --grub /dev/sda --hostname debian01 --password changeme
 
-Install Debian release buster on /dev/sda1 and install bootmanager GRUB in MBR (master boot record) of /dev/sda.
+Install Debian release bookworm on /dev/sda1 and install bootmanager GRUB in MBR (master boot record) of /dev/sda.
 Set hostname to 'debian01' and password for user root to 'changeme'.
 
   grml-debootstrap --target /dev/sda6 --grub /dev/sda --release sid
@@ -380,39 +380,16 @@ Supported Releases
 [width="40%",frame="topbot",options="header"]
 |======================
 |Release  |Status
-|buster   |works[1]
 |bullseye |works
 |bookworm |works
 |trixie   |works
-|sid      |works[2]
+|sid      |works[1]
 |======================
-
-[NOTE]
-.buster release
-================================================================================
-[1] Please notice that releases like buster are unsupported releases within Debian nowadays.
-grml-debootstrap can handle the releases but you really should not use them anymore unless you really know what you are doing.
-Even older versions are also entirely unsupported by grml-debootstrap.
-
-Choose the current Debian stable version instead.
-See https://wiki.debian.org/DebianReleases for the list of supported releases.
-
-Notice that you need to specify a specific mirror providing old releases, the default (http://deb.debian.org/debian) doesn't provide them any longer.
-Set the mirror to e.g. http://archive.debian.org/debian/ if you don't have your own Debian mirror.
-
-Older releases might also fail to install when running on top of recent kernel versions,
-throwing segfaults during debootstrap. This can be identified by the following messages inside kernel log (check with 'dmesg'):
-
-   dpkg[...] vsyscall attempted with vsyscall=none ip:[...]
-   dpkg[...]: segfault at [...]
-
-To work around this issue boot your system with the kernel boot option 'vsyscall=emulate'.
-================================================================================
 
 [NOTE]
 .unstable and testing releases
 ================================================================================
-[2] Please notice that Debian/testing and Debian/unstable (sid) might
+[1] Please notice that Debian/testing and Debian/unstable (sid) might
 not be always installable due to their nature. What _might_ work instead is
 deploying a stable release and upgrade it after installation finished.
 ================================================================================

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -37,9 +37,5 @@ bookworm: clean fake-uname.so install
 bullseye: clean fake-uname.so install
 	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
 
-# Debian 10
-buster: clean fake-uname.so install
-	packer build -var debian_version=$@ -var grml_debootstrap_version=$(GRML_DEBOOTSTRAP_VERSION) -var grml_debootstrap_local_path=$(GRML_DEBOOTSTRAP_LOCAL_PATH) debian64.json
-
-.PHONY: compile bullseye buster
+.PHONY: trixie bookworm bullseye
 .NOTPARALLEL:

--- a/packer/debian64_provision.sh
+++ b/packer/debian64_provision.sh
@@ -202,7 +202,7 @@ grml_debootstrap_execution() {
 apply_nic_workaround() {
   # release specific stuff
   case "$DEBIAN_VERSION" in
-    buster|bullseye|bookworm|trixie|unstable|sid)
+    bullseye|bookworm|trixie|unstable|sid)
       ;;
     *)
       echo "* Debian $DEBIAN_VERSION doesn't require NIC workaround"


### PR DESCRIPTION
The buster repository was moved to archive.debian.org, see https://lists.debian.org/debian-devel-announce/2025/06/msg00001.html We decided to no longer invest any further time into buster.

Relevant changes:

* Drop all buster related code/config/docs
* Replace buster with trixie, whenever applicable
* prompt_for_release(): do not hardcode height of dialog, but instead use "0" to use dialog's autodetection instead.
* config: update release information to match reality
* grml-debootstrap.8.txt: update documentation accordingly
* Makefile + packer/Makefile: the compile target is gone since commit 4d625ea05ba167d60766f86f2ff2edad2cfd561a

Closes: https://github.com/grml/grml-debootstrap/issues/349