### PR TITLE
Use deb822 sources format everywhere

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -92,6 +92,34 @@ markauto() {
 }
 # }}}
 
+# write a deb822 sources stanza to a file {{{
+writesource() {
+  local file types uris suites components signed_by
+
+  file="${1:-}"
+  types="${2:-}"
+  uris="${3:-}"
+  suites="${4:-}"
+  components="${5:-}"
+  signed_by="${6:-}"
+
+  mkdir -p "$(dirname "${file}")"
+
+  if [ -f "$file" ]; then
+    ## stanzas need a space between them and the previous stanza
+    echo '' >> "$file"
+  fi
+
+  echo "Types: $types" >> "$file"
+  echo "URIs: $uris" >> "$file"
+  echo "Suites: $suites" >> "$file"
+  echo "Components: $components" >> "$file"
+  if [ -n "$signed_by" ]; then
+    echo "Signed-By: $signed_by" >> "$file"
+  fi
+}
+# }}}
+
 # define chroot mirror {{{
 chrootmirror() {
   if [ "$KEEP_SRC_LIST" = "yes" ] ; then
@@ -105,8 +133,16 @@ chrootmirror() {
   echo "Using repository components $COMPONENTS"
 
   if [ -n "$MIRROR" ] ; then
-    echo "Adjusting sources.list for mirror (${MIRROR})."
-    echo "deb $MIRROR $RELEASE $COMPONENTS" > /etc/apt/sources.list
+    echo "Deleting obsolete sources.list"
+    rm -f /etc/apt/sources.list
+
+    if grep -q 'file:' <<< "$MIRROR" ; then
+      echo "Adjusting sources.list.d/local.sources for mirror (${MIRROR})."
+      writesource '/etc/apt/sources.list.d/local.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+    else
+      echo "Adjusting sources.list.d/debian.sources for mirror (${MIRROR})."
+      writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+    fi
   fi
 
   # add security.debian.org:
@@ -115,8 +151,8 @@ chrootmirror() {
     *)
       # bullseye and newer releases use a different repository layout, see
       # https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html
-      echo "Adding security.debian.org/debian-security to sources.list."
-      echo "deb http://security.debian.org/debian-security ${RELEASE}-security $COMPONENTS" >> /etc/apt/sources.list
+      echo "Adding security.debian.org/debian-security to sources.list.d/debian.sources."
+      writesource '/etc/apt/sources.list.d/debian.sources' 'deb' 'http://security.debian.org/debian-security' "${RELEASE}-security" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
       ;;
   esac
 }
@@ -130,11 +166,10 @@ remove_chrootmirror() {
   fi
 
   if [ -n "$MIRROR" ] && echo "$MIRROR" | grep -q 'file:' ; then
-    echo "Removing local mirror (${MIRROR}) from sources.list."
-    TMP_MIRROR="${MIRROR//\//\\\/}"
-    sed -i "/deb $TMP_MIRROR $RELEASE $COMPONENTS/ D" /etc/apt/sources.list
-    echo "Adding fallback mirror entry (${FALLBACK_MIRROR}) to sources.list instead."
-    echo "deb $FALLBACK_MIRROR $RELEASE $COMPONENTS" >> /etc/apt/sources.list
+    echo "Removing local.sources."
+    rm /etc/apt/sources.list.d/local.sources
+    echo "Adding fallback mirror entry (${FALLBACK_MIRROR}) to sources.list.d/debian.sources instead."
+    writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$FALLBACK_MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
   fi
 }
 # }}}
@@ -146,19 +181,15 @@ grmlrepos() {
   fi
 
   # user might have provided their own apt sources configuration
-  if [ -r /etc/apt/sources.list.d/grml.list ] ; then
-    echo "File /etc/apt/sources.list.d/grml.list exists already, not modifying."
+  if [ -r /etc/apt/sources.list.d/grml.sources ] ; then
+    echo "File /etc/apt/sources.list.d/grml.sources exists already, not modifying."
   else
-    echo "Setting up /etc/apt/sources.list.d/grml.list."
-    cat > /etc/apt/sources.list.d/grml.list << EOF
-# grml: stable repository:
-  deb     [signed-by=/usr/share/keyrings/grml-archive-keyring.gpg] http://deb.grml.org/ grml-stable main
-  deb-src [signed-by=/usr/share/keyrings/grml-archive-keyring.gpg] http://deb.grml.org/ grml-stable main
-
-# grml: testing/development repository:
-  deb     [signed-by=/usr/share/keyrings/grml-archive-keyring.gpg] http://deb.grml.org/ grml-testing main
-  deb-src [signed-by=/usr/share/keyrings/grml-archive-keyring.gpg] http://deb.grml.org/ grml-testing main
-EOF
+    echo "Setting up /etc/apt/sources.list.d/grml.sources."
+    echo '# grml: stable repository:' >> /etc/apt/sources.list.d/grml.sources
+    writesource '/etc/apt/sources.list.d/grml.sources' 'deb deb-src' 'https://deb.grml.org' 'grml-stable' 'main' '/usr/share/keyrings/grml-archive-keyring.gpg'
+    echo '' >> /etc/apt/sources.list.d/grml.sources
+    echo '# grml: testing/development repository:' >> /etc/apt/sources.list.d/grml.sources
+    writesource '/etc/apt/sources.list.d/grml.sources' 'deb deb-src' 'https://deb.grml.org' 'grml-testing' 'main' '/usr/share/keyrings/grml-archive-keyring.gpg'
   fi
 
   # make sure we install packages from Grml's pool only if not available from Debian
@@ -188,11 +219,8 @@ EOF
 # feature to provide Debian backports repos {{{
 backportrepos() {
   if [ -n "$BACKPORTREPOS" ] ; then
-    cat >> /etc/apt/sources.list.d/backports.list << EOF
-# debian backports: ${RELEASE}-backports repository:
-deb     ${MIRROR} ${RELEASE}-backports main
-deb-src ${MIRROR} ${RELEASE}-backports main
-EOF
+    echo "# debian backports: ${RELEASE}-backports repository:" >> /etc/apt/sources.list.d/backports.sources
+    writesource '/etc/apt/sources.list.d/backports.sources' 'deb deb-src' "$MIRROR" "${RELEASE}-backports" 'main' '/usr/share/keyrings/debian-archive-keyring.gpg'
   fi
 }
 # }}}

--- a/config
+++ b/config
@@ -41,17 +41,19 @@
 # BOOT_APPEND='pci=nomsi'
 
 # Set mirror where packages will be downloaded from.
-# Default: use /etc/debootstrap/etc/apt/sources.list if it exists, else
-# 'http://deb.debian.org/debian'
+# Default: use /etc/debootstrap/etc/apt/sources.list.d/debian.sources if it
+# exists, else use /etc/debootstrap/etc/apt/sources.list if it exists, else
+# use 'http://deb.debian.org/debian'
 # Usage example:
 # MIRROR='ftp://ftp.de.debian.org/debian'
 
-# If /etc/apt/sources.list should NOT be build on the fly, this
-# options allows providing a separate apt sources.list file via
-# /etc/debootstrap/etc/apt/sources.list
+# If /etc/apt/sources.list.d/debian.sources should NOT be built on the fly,
+# this option allows providing a separate apt sources.list file via
+# /etc/debootstrap/etc/apt/sources.list, or providing a deb822-format sources
+# file via /etc/debootstrap/etc/apt/sources.list.d/debian.sources.
 # KEEP_SRC_LIST='yes'
 
-# To enable the Grml repository via /etc/apt/sources.list.d/grml.list
+# To enable the Grml repository via /etc/apt/sources.list.d/grml.sources
 # set this variable to 'yes'.
 # Default: 'no'
 # GRMLREPOS='yes'
@@ -62,7 +64,7 @@
 # GRMLPACKAGES='grml-etc-core'
 
 # To enable Debian's backports repository via
-# /etc/apt/sources.list.d/backports.list set this variable to 'yes'.
+# /etc/apt/sources.list.d/backports.sources set this variable to 'yes'.
 # Default: 'no'
 # BACKPORTREPOS='yes'
 
@@ -71,7 +73,7 @@
 # Default: 'trixie'
 # RELEASE='trixie'
 
-# Define components that should be used within sources.list.
+# Define components that should be used within sources.list.d/debian.sources.
 # Default: 'main'
 # COMPONENTS='main contrib non-free'
 

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -139,7 +139,7 @@ Configuration options:
       --debconf <file>     Pre-seed packages using specified pre-seed db file.
       --grmlrepos          Enable Grml's Debian repository (deb.grml.org).
       --backportrepos      Enable Debian's backports repository (backports.debian.org).
-      --keep_src_list      Do not overwrite user provided apt sources.list.
+      --keep_src_list      Do not override user provided apt sources.
       --contrib            Enable 'contrib' in COMPONENTS (defaults to 'main' only).
       --non-free           Enable non-free / non-free-firmware in COMPONENTS (defaults to 'main' only).
       --hostname <name>    Hostname of Debian system.
@@ -461,7 +461,7 @@ while :; do
     shift; _opt_chroot_scripts="$1"
     _opt_chroot_scripts_set=T
     ;;
-  --keep_src_list)     # Do not overwrite user provided apt sources.list
+  --keep_src_list)     # Do not override user provided apt sources
     _opt_keep_src_list=T
     ;;
   --hostname)          # Hostname of Debian system

--- a/grml-debootstrap.8.adoc
+++ b/grml-debootstrap.8.adoc
@@ -40,8 +40,8 @@ Options and environment variables
 *--backportrepos*::
 
     Enable Debian's Backports repository via the
-    /etc/apt/sources.list.d/backports.list configuration file. This provides the
-    option to install Debian packages from Debian's backports repository.
+    /etc/apt/sources.list.d/backports.sources configuration file. This provides
+    the option to install Debian packages from Debian's backports repository.
 
 *--bootappend* _appendline-for-the-kernel_::
 
@@ -113,7 +113,7 @@ Options and environment variables
 *--grmlrepos*::
 
     Enable Grml.org's Debian repository (http://deb.grml.org/) via the
-    /etc/apt/sources.list.d/grml.list configuration file. This provides the
+    /etc/apt/sources.list.d/grml.sources configuration file. This provides the
     option to install Debian packages from Grml's repository.
 
 *--grub* _device_::
@@ -135,7 +135,8 @@ Options and environment variables
 
 *--keep_src_list*::
 
-     Do not overwrite user provided /etc/apt/sources.list.
+     Do not override user provided /etc/apt/sources.list.d/debian.sources or
+     delete /etc/apt/sources.list.
 
 *-m*, *--mirror* _URL_::
 


### PR DESCRIPTION
This should be a relatively straightforward change. I went through all files searching for `list` and `deb `, porting any one-line format code to deb822 as I went.

Unfortunately, the most complex bit of code, the `deletesource` function in `chroot-script`, has not been tested in an actual VM build, as I'm not sure how to even trigger it. `$MIRROR` has to be a `file:` URL for `remove_chrootmirror` to be called, and that's the only function that calls `deletesource`. But for `$MIRROR` to be a `file:` URL, the contents of the mirror would have to be signed by the Debian archive keyring, which means I'd need to clone the Debian archive or some substantial portion thereof, which I don't currently know how to do. I *have* tested `deletesource` in an interactive Bash shell and it seems to work in a couple of scenarios (copy `/usr/share/doc/apt/examples/debian.sources` to your home dir, then try `deletesource ~/debian.sources 'deb' 'http://deb.debian.org/debian' 'trixie trixie-updates' 'main contrib non-free non-free-firmware' '/usr/share/keyrings/debian-archive-keyring.gpg'` and `deletesource ~/debian.sources 'deb' 'http://deb.debian.org/debian-security' 'trixie-security'`, see what happens to the file).

I also did not test `packer/debian64_provision.sh` as I don't know how it's intended to be used. It looks like it's part of Grml's CI system?

Fixes https://github.com/grml/grml-debootstrap/issues/203.