### PR TITLE
Increase size of release selection dialog

### DIFF
--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -892,7 +892,7 @@ prompt_for_release()
   local default_value="$RELEASE"
   RELEASE="$(dialog --stdout --title "${PN}" --default-item "$default_value" --menu \
             "Please enter the Debian release you would like to use for installation:" \
-            0 50 0 \
+            16 50 5 \
             bookworm Debian/12 \
             trixie   Debian/13 \
             sid      Debian/unstable)" \


### PR DESCRIPTION
With the previous setttings, the line containing "sid" will be hidden behind a "scrollbar".

Old:

<img width="1270" height="791" alt="Screenshot 2026-04-29 at 11 24 41" src="https://github.com/user-attachments/assets/5da64e9a-fb47-4d88-b7e8-45606c37d008" />

New:

<img width="1273" height="792" alt="Screenshot 2026-04-29 at 11 24 57" src="https://github.com/user-attachments/assets/4157b27b-ec4b-452a-8d12-9a6d2d981846" />
