### PR TITLE
GHA CI: restrict test-build push trigger to master

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -8,9 +8,6 @@ permissions:
   actions: read
   contents: read
   pull-requests: write
-concurrency:
-  group: "${{ github.ref }}"
-  cancel-in-progress: true
 jobs:
   build-debian:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     - cron: '30 3 * * 2'
 


### PR DESCRIPTION
Avoid GitHub actions auto-cancellations, hopefully. Which GitHub now treats as errors, at least in the per-commit view.

Claude explanation which is partially wrong:
> Pushes to PR-ed branches were triggering test-build twice: once via the push event and once via the matching pull_request event.
> The duplicate matrix run wasted ~20-35 minutes per push, and the concurrency cancel-in-progress occasionally cancelled one of the two, surfacing the PR as a red cross on the commit.
> Restrict push to master only; PR development still gets one full run via the pull_request trigger, master keeps push-tested post-merge, and the weekly schedule is unchanged.
