### PR TITLE
Stop creating /etc/kernel-img.conf

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -237,7 +237,6 @@ kernelimg_conf() {
      cat > /etc/kernel-img.conf << EOF
 # Kernel Image management overrides
 # See kernel-img.conf(5) for details
-do_initrd = Yes
 do_symlinks = Yes
 EOF
   fi

--- a/chroot-script
+++ b/chroot-script
@@ -229,20 +229,6 @@ backportrepos() {
 }
 # }}}
 
-# set up kernel-img.conf {{{
-# shellcheck disable=SC2329
-kernelimg_conf() {
-  if ! [ -r /etc/kernel-img.conf ] ; then
-     echo "Setting up /etc/kernel-img.conf"
-     cat > /etc/kernel-img.conf << EOF
-# Kernel Image management overrides
-# See kernel-img.conf(5) for details
-do_symlinks = Yes
-EOF
-  fi
-}
-# }}}
-
 # make sure services do not start up {{{
 # shellcheck disable=SC2329
 install_policy_rcd() {
@@ -922,7 +908,7 @@ trap signal_handler HUP INT QUIT TERM
  # always execute install_policy_rcd
  install_policy_rcd
 
- for i in markauto chrootmirror grmlrepos backportrepos kernelimg_conf \
+ for i in markauto chrootmirror grmlrepos backportrepos \
      kernel packages extrapackages reconfigure hosts \
      default_locales timezone fstab install_fs_tools hostname \
      initrd grub_install passwords \


### PR DESCRIPTION
Compare https://salsa.debian.org/kernel-team/linux-base/-/commit/9977e3b63ba7d7f5bfcd2371505de245cf3e4000 .

- do_initrd is useless since 2016
- do_symlinks=yes is the default since 2016

Pointed out by cacin on IRC.