### PR TITLE
Add full support for reproducible image builds

### DIFF
--- a/chroot-script
+++ b/chroot-script
@@ -387,7 +387,7 @@ rpi_cmdline() {
 reconfigure() {
   if [ -n "$RECONFIGURE" ] ; then
      for package in $RECONFIGURE ; do
-         if dpkg --list "$package" >/dev/null 2>&1 | grep -q '^ii' ; then
+         if dpkg --list "$package" 2>/dev/null | grep -q '^ii' ; then
            DEBIAN_FRONTEND=$DEBIAN_FRONTEND dpkg-reconfigure "$package" || \
            echo "Warning: $package does not exist, can not reconfigure it."
          fi

--- a/chroot-script
+++ b/chroot-script
@@ -405,14 +405,9 @@ passwords()
     return 0
   fi
 
-  CHPASSWD_OPTION=
-  if chpasswd --help 2>&1 | grep -q -- '-m,' ; then
-     CHPASSWD_OPTION='-m'
-  fi
-
   if [ -n "$ROOTPASSWORD" ] ; then
      # shellcheck disable=SC2086
-     echo root:"$ROOTPASSWORD" | chpasswd $CHPASSWD_OPTION
+     echo root:"$ROOTPASSWORD" | chpasswd
      export ROOTPASSWORD=''
   else
     a='1'
@@ -435,7 +430,7 @@ passwords()
          b='2'
        else
          # shellcheck disable=SC2086
-         echo root:"$a" | chpasswd $CHPASSWD_OPTION
+         echo root:"$a" | chpasswd
          unset a
          unset b
        fi

--- a/chroot-script
+++ b/chroot-script
@@ -33,6 +33,9 @@ bash -n /etc/debootstrap/variables
 # shellcheck source=tests/shellcheck-stub-debootstrap-variables
 . /etc/debootstrap/variables || exit 1
 
+# Make sure all tools see SOURCE_DATE_EPOCH if it's available
+[ -v SOURCE_DATE_EPOCH ] && export SOURCE_DATE_EPOCH
+
 [ -r /proc/1 ] || mount -t proc none /proc
 [ -r /sys/kernel ] || mount -t sysfs none /sys
 
@@ -95,7 +98,7 @@ markauto() {
 
 # write a deb822 sources stanza to a file {{{
 writesource() {
-  local file types uris suites components signed_by
+  local file types uris suites components signed_by check_valid_until
 
   file="${1:-}"
   types="${2:-}"
@@ -103,6 +106,7 @@ writesource() {
   suites="${4:-}"
   components="${5:-}"
   signed_by="${6:-}"
+  check_valid_until="${7:-}"
 
   mkdir -p "$(dirname "${file}")"
 
@@ -118,12 +122,19 @@ writesource() {
   if [ -n "$signed_by" ]; then
     echo "Signed-By: $signed_by" >> "$file"
   fi
+  if [ -n "$check_valid_until" ]; then
+    echo "Check-Valid-Until: $check_valid_until" >> "$file"
+  fi
 }
 # }}}
 
 # define chroot mirror {{{
 # shellcheck disable=SC2329
 chrootmirror() {
+  local omit_check_valid_until check_valid_until
+  omit_check_valid_until="${1:-}"
+  check_valid_until=''
+
   if [ "$KEEP_SRC_LIST" = "yes" ] ; then
     echo "KEEP_SRC_LIST has been enabled, skipping chrootmirror stage."
     return
@@ -134,26 +145,34 @@ chrootmirror() {
   fi
   echo "Using repository components $COMPONENTS"
 
+  [ -v SOURCE_DATE_EPOCH ] && [ -z "${omit_check_valid_until}" ] \
+    && check_valid_until='no'
+
   if [ -n "$MIRROR" ] ; then
     echo "Deleting obsolete sources.list"
     rm -f /etc/apt/sources.list
 
     if grep -q 'file:' <<< "$MIRROR" ; then
       echo "Adjusting sources.list.d/local.sources for mirror (${MIRROR})."
-      writesource '/etc/apt/sources.list.d/local.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+      writesource '/etc/apt/sources.list.d/local.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg' "${check_valid_until}"
     else
       echo "Adjusting sources.list.d/debian.sources for mirror (${MIRROR})."
-      writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+      writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg' "${check_valid_until}"
     fi
   fi
 
-  # add security.debian.org:
+  # add security mirror:
   case "$RELEASE" in
     unstable|sid) ;;  # no security pool available
     *)
       # https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html
-      echo "Adding security.debian.org/debian-security to sources.list.d/debian.sources."
-      writesource '/etc/apt/sources.list.d/debian.sources' 'deb' 'http://security.debian.org/debian-security' "${RELEASE}-security" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+      if grep -q 'file:' <<< "$SECURITY_MIRROR" ; then
+        echo "Adding security mirror to sources.list.d/local.sources."
+        writesource '/etc/apt/sources.list.d/local.sources' 'deb' "$SECURITY_MIRROR" "${RELEASE}-security" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg' "${check_valid_until}"
+      else
+        echo "Adding security mirror to sources.list.d/debian.sources."
+        writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$SECURITY_MIRROR" "${RELEASE}-security" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg' "${check_valid_until}"
+      fi
       ;;
   esac
 }
@@ -169,9 +188,16 @@ remove_chrootmirror() {
 
   if [ -n "$MIRROR" ] && echo "$MIRROR" | grep -q 'file:' ; then
     echo "Removing local.sources."
-    rm /etc/apt/sources.list.d/local.sources
+    rm -f /etc/apt/sources.list.d/local.sources
     echo "Adding fallback mirror entry (${FALLBACK_MIRROR}) to sources.list.d/debian.sources instead."
     writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$FALLBACK_MIRROR" "$RELEASE" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
+  fi
+
+  if [ -n "$SECURITY_MIRROR" ] && echo "$SECURITY_MIRROR" | grep -q 'file:' ; then
+    echo "Removing local.sources if necessary."
+    rm -rf /etc/apt/sources.list.d/local.sources
+    echo "Adding fallback security mirror entry (${FALLBACK_SECURITY_MIRROR}) to sources.list.d/debian.sources instead."
+    writesource '/etc/apt/sources.list.d/debian.sources' 'deb' "$FALLBACK_SECURITY_MIRROR" "${RELEASE}-security" "$COMPONENTS" '/usr/share/keyrings/debian-archive-keyring.gpg'
   fi
 }
 # }}}
@@ -223,8 +249,13 @@ EOF
 # shellcheck disable=SC2329
 backportrepos() {
   if [ -n "$BACKPORTREPOS" ] ; then
+    local omit_check_valid_until check_valid_until
+    omit_check_valid_until="${1:-}"
+    check_valid_until=''
+    [ -v SOURCE_DATE_EPOCH ] && [ -z "${omit_check_valid_until}" ] \
+      && check_valid_until='no'
     echo "# debian backports: ${RELEASE}-backports repository:" >> /etc/apt/sources.list.d/backports.sources
-    writesource '/etc/apt/sources.list.d/backports.sources' 'deb deb-src' "$MIRROR" "${RELEASE}-backports" 'main' '/usr/share/keyrings/debian-archive-keyring.gpg'
+    writesource '/etc/apt/sources.list.d/backports.sources' 'deb deb-src' "$MIRROR" "${RELEASE}-backports" 'main' '/usr/share/keyrings/debian-archive-keyring.gpg' "${check_valid_until}"
   fi
 }
 # }}}
@@ -406,9 +437,22 @@ passwords()
   fi
 
   if [ -n "$ROOTPASSWORD" ] ; then
-     # shellcheck disable=SC2086
-     echo root:"$ROOTPASSWORD" | chpasswd
-     export ROOTPASSWORD=''
+    if [ -v SOURCE_DATE_EPOCH ]; then
+      local pass_hash
+      pass_hash="$(perl -e \
+        'print crypt($ARGV[0], "\$y\$j9T\$".$ARGV[1]."\$")' \
+        "$ROOTPASSWORD" "$ROOTPASSWORD_SALT")"
+      # Regex taken from the 'yescrypt' section of 'man 5 crypt'
+      if ! [[ "${pass_hash}" =~ \$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43} ]]; then
+        echo "Error: failed to generate a reproducible password hash."
+        exit 1
+      fi
+      echo "root:${pass_hash}" | chpasswd -e
+    else
+      # shellcheck disable=SC2086
+      echo root:"$ROOTPASSWORD" | chpasswd
+    fi
+    export ROOTPASSWORD=''
   else
     a='1'
     b='2'
@@ -489,8 +533,14 @@ timezone() {
 # shellcheck disable=SC2329
 createfstab(){
   echo "Setting up /etc/fstab"
+  local fstab_created_on
+  if [ -v SOURCE_DATE_EPOCH ]; then
+    fstab_created_on="$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH}")"
+  else
+    fstab_created_on="$(date)"
+  fi
   cat > /etc/fstab <<EOF
-# /etc/fstab - created by grml-debootstrap on $(date)
+# /etc/fstab - created by grml-debootstrap on ${fstab_created_on}
 # Accessible filesystems, by reference, are maintained under '/dev/disk/'.
 # See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info.
 #
@@ -711,19 +761,14 @@ is_grub_bios_compatible() {
     return 0
   # Look for a BIOS boot partition otherwise
   else
-    SEARCH_STR="$GRUB"
-    if [[ "$SEARCH_STR" =~ ^/dev/loop ]]; then
-      SEARCH_STR="${SEARCH_STR//\/dev\//}" # loopX
-      SEARCH_STR="/dev/mapper/${SEARCH_STR}" # /dev/mapper/loopX
-      # Note that /dev/mapper/loopX won't actually exist, but
-      # /dev/mapper/loopXpY will, so this works for the regex check in the
-      # while loop below.
+    # Scanning the output of lsblk is unreliable in some environments. partx
+    # seems to work better.
+    local partx_types
+    partx_types="$(partx --show --noheadings --output TYPE "$GRUB")" || true
+    if [[ "${partx_types}" \
+      =~ (^|$'\n')21686148-6449-6e6f-744e-656564454649($'\n'|$) ]]; then
+      return 0
     fi
-    while read -r line; do
-      if [[ "$line" =~ ^${SEARCH_STR}.*21686148-6449-6e6f-744e-656564454649$ ]]; then
-        return 0
-      fi
-    done < <(lsblk -pnlo NAME,PARTTYPE)
   fi
   return 1
 }
@@ -885,6 +930,68 @@ finalize() {
 }
 # }}}
 
+# reproducible-build finalization {{{
+reproducible_finalize() {
+  [ -v SOURCE_DATE_EPOCH ] || return 0
+  echo "Applying reproducible-build finalization."
+
+  # Regenerate apt sources with their final values.
+  if [ -n "${FINAL_MIRROR}" ]; then
+    MIRROR="${FINAL_MIRROR}"
+  fi
+  if [ -n "${FINAL_SECURITY_MIRROR}" ]; then
+    SECURITY_MIRROR="${FINAL_SECURITY_MIRROR}"
+  fi
+  rm -f '/etc/apt/sources.list.d/debian.sources'
+  rm -f '/etc/apt/sources.list.d/backports.sources'
+  chrootmirror 'omit-check-valid-until'
+  backportrepos 'omit-check-valid-until'
+  remove_chrootmirror
+
+  # stale apt repository information
+  find /var/lib/apt/lists -mindepth 1 -maxdepth 1 -type f -delete
+  find /var/lib/apt/lists/auxfiles -mindepth 1 -maxdepth 1 -type f -delete
+  find /var/lib/apt/lists/partial -mindepth 1 -maxdepth 1 -type f -delete
+
+  # SSH host keys
+  rm -f /etc/ssh/ssh_host_*
+
+  # Postfix aliases.db
+  # TODO: Simply deleting this file may cause problems for the system
+  # admnistrator later. Modifying it requires adding db-util to the image.
+  # Regenerating it with a fixed timestamp seems to be impossible (newaliases
+  # does not support it, and running newaliases under 'faketime -f' causes it
+  # to freeze indefinitely).
+  rm -f /etc/aliases.db
+
+  # machine-id
+  printf 'uninitialized\n' > /etc/machine-id
+  rm -f /var/lib/dbus/machine-id # copied from /etc/machine-id on boot
+
+  # logs
+  rm -f /var/log/alternatives.log /var/log/dpkg.log /var/log/apt/history.log \
+    /var/log/apt/term.log
+
+  # ldconfig auxiliary cache (this seems to be undocumented, ldconfig
+  # regenerates it)
+  rm -f /var/cache/ldconfig/aux-cache
+
+  # files that shouldn't have gotten stuck in /run but did anyway
+  local rm_run_obj
+  for rm_run_obj in /run/*; do
+    if [ -e "${rm_run_obj}" ] && [ "${rm_run_obj}" != '/run/udev' ]; then
+      rm -rf "${rm_run_obj}"
+    fi
+  done
+
+  # locale configuration, lines may be in a nondeterministic order
+  [ -f /etc/locale.conf ] && LC_ALL=C sort -o /etc/locale.conf /etc/locale.conf
+
+  # our own grml-debootstrap configuration
+  rm -f /etc/debootstrap/config
+}
+# }}}
+
 # signal handler {{{
 # shellcheck disable=SC2329
 signal_handler() {
@@ -908,7 +1015,7 @@ trap signal_handler HUP INT QUIT TERM
      default_locales timezone fstab install_fs_tools hostname \
      initrd grub_install passwords \
      custom_scripts upgrade_system rpi_cmdline remove_apt_cache services \
-     remove_chrootmirror; do
+     remove_chrootmirror reproducible_finalize; do
      if stage "$i" ; then
        "$i"
        stage "$i" 'done'

--- a/config
+++ b/config
@@ -47,6 +47,18 @@
 # Usage example:
 # MIRROR='ftp://ftp.de.debian.org/debian'
 
+# Set mirror where security updates will be downloaded from.
+# Default: http://security.debian.org/debian-security
+# SECURITY_MIRROR='http://security.debian.org/debian-security'
+
+# Set Debian snapshot instance where initial packages will be downloaded from
+# when reproducible builds are enabled. The normal mirror and security mirror
+# will be derived from this during a reproducible build, but the originally
+# set mirror and security mirror will be set up so the image uses the desired
+# mirrors in actual operation.
+# Default: https://snapshot.debian.org/archive
+# SNAPSHOT_ARCHIVE='https://snapshot.debian.org/archive'
+
 # If /etc/apt/sources.list.d/debian.sources should NOT be built on the fly,
 # this option allows providing a separate apt sources.list file via
 # /etc/debootstrap/etc/apt/sources.list, or providing a deb822-format sources
@@ -93,6 +105,15 @@
 # Please change this password after installation for security reasons.
 # Default: no default.
 # ROOTPASSWORD=''
+
+# Root password salt for reproducible builds. This is a base64-encoded value,
+# where the characters used are '.', '/', 'A-Z', 'a-z', and '0-9'.
+# If unset, and SOURCE_DATE_EPOCH is set, this is pseudorandomly generated
+# from a seed derived from SOURCE_DATE_EPOCH. Anyone who knows approximately
+# when the image was built can build a rainbow table to attack the root
+# password without needing the password hashes first. If this risk is
+# unacceptable, generate a salt securely and place it here.
+# ROOTPASSWORD_SALT=''
 
 # Pass extra options to mmdebstrap.
 # Default: no default.
@@ -213,27 +234,31 @@
 # Default: '/etc/debootstrap/install_notes' (empty file).
 # INSTALL_NOTES='/etc/debootstrap/install_notes'
 
-# Use fixed disk identifiers for Virtual Machine builds.
-# Useful for reproducible builds.
-# Default: 'no'
-# FIXED_DISK_IDENTIFIERS='yes'
+# The date at which the installed system should be "frozen". Set this to
+# enable reproducible builds.
+# Default: unset
+# SOURCE_DATE_EPOCH=''
 
-# Filesystem identifier when using FIXED_DISK_IDENTIFIERS='yes'.
+# Filesystem identifier when SOURCE_DATE_EPOCH is set.
 # Use uuid-runtime's uuidgen tool to generate random UUIDs on demand.
-# Default: '26ada0c0-1165-4098-884d-aafd2220c2c6'
+# Default: Pseudorandomly generated from a seed derived from SOURCE_DATE_EPOCH
 # FS_IDENTIFIER="$(uuidgen)"
 
-# Disk identifier for MBR partition tables when using
-# FIXED_DISK_IDENTIFIERS='yes'. Note that this is used even if a GPT partition
-# table is in use, as it is used as the ID for the GPT's protective MBR.
-# Default: '0x41414141'
-# MBR_IDENTIFIER="0x12345678"
+# Filesystem hash seed when SOURCE_DATE_EPOCH is set.
+# Default: Pseudorandomly generated from a seed derived from SOURCE_DATE_EPOCH
+# FS_HASH_SEED="12345678-9012-3456-7890-123456789012"
 
-# The first three portions of the GUID identifier for individual partitions
-# when using FIXED_DISK_IDENTIFIERS='yes'. The final portion of the identifier
-# is derived from the partition number for each partition.
-# Default: 'b3170792-c1b6-4b84-b6ac'
+# The first four portions of the UUID identifier for individual partitions
+# when SOURCE_DATE_EPOCH is set. The final portion of the identifier is
+# derived from the partition number for each partition.
+# Default: Pseudorandomly generated from a seed derived from SOURCE_DATE_EPOCH
 # GPT_IDENTIFIER_PREFIX="12345678-9012-3456-7890"
+
+# Disk identifier for MBR partition tables when SOURCE_DATE_EPOCH is set.
+# Note that this is used even if a GPT partition table is in use, as it is
+# used as the ID for the GPT's protective MBR.
+# Default: Pseudorandomly generated from a seed derived from SOURCE_DATE_EPOCH
+# MBR_IDENTIFIER="0x12345678"
 
 # Delete grml-debootstrap configuration files from installed system.
 # Useful for reproducible builds or if you don't want to leak information.

--- a/config
+++ b/config
@@ -223,6 +223,18 @@
 # Default: '26ada0c0-1165-4098-884d-aafd2220c2c6'
 # FS_IDENTIFIER="$(uuidgen)"
 
+# Disk identifier for MBR partition tables when using
+# FIXED_DISK_IDENTIFIERS='yes'. Note that this is used even if a GPT partition
+# table is in use, as it is used as the ID for the GPT's protective MBR.
+# Default: '0x41414141'
+# MBR_IDENTIFIER="0x12345678"
+
+# The first three portions of the GUID identifier for individual partitions
+# when using FIXED_DISK_IDENTIFIERS='yes'. The final portion of the identifier
+# is derived from the partition number for each partition.
+# Default: 'b3170792-c1b6-4b84-b6ac'
+# GPT_IDENTIFIER_PREFIX="12345678-9012-3456-7890"
+
 # Delete grml-debootstrap configuration files from installed system.
 # Useful for reproducible builds or if you don't want to leak information.
 # Default: 'no'

--- a/config
+++ b/config
@@ -218,10 +218,10 @@
 # Default: 'no'
 # FIXED_DISK_IDENTIFIERS='yes'
 
-# Disk identifier when using FIXED_DISK_IDENTIFIERS='yes'.
+# Filesystem identifier when using FIXED_DISK_IDENTIFIERS='yes'.
 # Use uuid-runtime's uuidgen tool to generate random UUIDs on demand.
 # Default: '26ada0c0-1165-4098-884d-aafd2220c2c6'
-# DISK_IDENTIFIER="$(uuidgen)"
+# FS_IDENTIFIER="$(uuidgen)"
 
 # Delete grml-debootstrap configuration files from installed system.
 # Useful for reproducible builds or if you don't want to leak information.

--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,8 @@ Recommends:
  kpartx,
  parted,
  qemu-utils,
+ mtools,
+ python3,
 Description: installer for pure Debian
  Installation program for Debian, for bare-metal and virtual
  machines.

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -50,7 +50,7 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$DEBIAN_FRONTEND" ] || DEBIAN_FRONTEND='noninteractive'
 [ -n "$DEFAULT_LANGUAGE" ] || DEFAULT_LANGUAGE='en_US:en'
 [ -n "$DEFAULT_LOCALES" ] || DEFAULT_LOCALES='en_US.UTF-8'
-[ -n "$DISK_IDENTIFIER" ] || DISK_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
+[ -n "$FS_IDENTIFIER" ] || FS_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
 [ -n "$EXTRAPACKAGES" ] || EXTRAPACKAGES='yes'
 [ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://deb.debian.org/debian'
 [ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
@@ -1311,8 +1311,8 @@ mkfs() {
         eerror "Not changing disk uuid for $TARGET because $MKFS doesn't seem to match for ext{2,3,4} file system"
         bailout 1
       else
-        einfo "Changing disk uuid for $TARGET to fixed (non-random) value $DISK_IDENTIFIER using tune2fs"
-        tune2fs "$TARGET" -U "$DISK_IDENTIFIER" </dev/null
+        einfo "Changing disk uuid for $TARGET to fixed (non-random) value $FS_IDENTIFIER using tune2fs"
+        tune2fs "$TARGET" -U "$FS_IDENTIFIER" </dev/null
       fi
     fi
 

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -42,6 +42,17 @@ else
 fi
 VERSION="${VERSION:-unknown}"
 MNTPOINT="/mnt/debootstrap.$$"
+HAS_FWBOOT_PART='no'
+
+# used for reproducible builds
+(( ID_DERIVE_IDX = 0x7fffffffffffffff ))
+FWBOOT_REIMAGE_TREE=''
+ROOTFS_REIMAGE_TREE=''
+RANDOM_HEX_BYTES_LIST=()
+RANDOM_HEX_BYTE_IDX=0
+FINAL_MIRROR=''
+FINAL_SECURITY_MIRROR=''
+SOURCE_DATE_EPOCH_PRETTY=''
 
 # defaults
 [ -n "$CHROOT_SCRIPTS" ] || CHROOT_SCRIPTS='yes'
@@ -51,11 +62,13 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$DEFAULT_LANGUAGE" ] || DEFAULT_LANGUAGE='en_US:en'
 [ -n "$DEFAULT_LOCALES" ] || DEFAULT_LOCALES='en_US.UTF-8'
 [ -n "$FS_IDENTIFIER" ] || FS_IDENTIFIER='00000000-0000-0000-0000-000000000000'
+[ -n "$FS_HASH_SEED" ] || FS_HASH_SEED='00000000-0000-0000-0000-000000000000'
 [ -n "$GPT_IDENTIFIER_PREFIX" ] || GPT_IDENTIFIER_PREFIX='00000000-0000-0000-0000'
 [ -n "$MBR_IDENTIFIER" ] || MBR_IDENTIFIER='0x00000000'
+[ -n "$ROOTPASSWORD_SALT" ] || ROOTPASSWORD_SALT='0'
 [ -n "$EXTRAPACKAGES" ] || EXTRAPACKAGES='yes'
 [ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://deb.debian.org/debian'
-[ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
+[ -n "$FALLBACK_SECURITY_MIRROR" ] || FALLBACK_SECURITY_MIRROR='http://security.debian.org/debian-security'
 [ -n "$FORCE" ] || FORCE=''
 [ -n "$HOSTNAME" ] || HOSTNAME='grml'
 [ -n "$INITRD" ] || INITRD='yes'
@@ -64,6 +77,8 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$INSTALL_NOTES" ] || INSTALL_NOTES='/etc/debootstrap/install_notes'
 [ -n "$LOCALES" ] || LOCALES='yes'
 [ -n "$MIRROR" ] || MIRROR="$FALLBACK_MIRROR"
+[ -n "$SECURITY_MIRROR" ] || SECURITY_MIRROR="$FALLBACK_SECURITY_MIRROR"
+[ -n "$SNAPSHOT_ARCHIVE" ] || SNAPSHOT_ARCHIVE='https://snapshot.debian.org/archive'
 [ -n "$MKFS" ] || MKFS='mkfs.ext4'
 [ -n "$MKFS_OPTS" ] || MKFS_OPTS=''
 [ -n "$PACKAGES" ] || PACKAGES='yes'
@@ -253,6 +268,17 @@ check4progs(){
      return 1
   fi
 }
+
+check_mke2fs_version(){
+  local version_output version
+  version_output="$(mkfs.ext4 -V 2>&1)"
+  version="$(head -n1 <<< "${version_output}")"
+  version="$(cut -d' ' -f2 <<< "${version}")"
+  if dpkg --compare-versions "${version}" ge '1.47.1' ; then
+    return 0
+  fi
+  return 1
+}
 # }}}
 
 # unmount mountpoint {{{
@@ -283,6 +309,19 @@ try_umount() {
 
 # helper functions {{{
 cleanup() {
+  # Make sure the reimage tree dir names look like actual temp dir names
+  # before deleting them, so we don't accidentally destroy the user's data
+  # shellcheck disable=SC2076
+  if [ -d "${FWBOOT_REIMAGE_TREE}" ] \
+    && [[ "${FWBOOT_REIMAGE_TREE}" =~ '/tmp.' ]] ; then
+    rm -rf "${FWBOOT_REIMAGE_TREE}"
+  fi
+  # shellcheck disable=SC2076
+  if [ -d "${ROOTFS_REIMAGE_TREE}" ] \
+    && [[ "${ROOTFS_REIMAGE_TREE}" =~ '/tmp.' ]] ; then
+    rm -rf "${ROOTFS_REIMAGE_TREE}"
+  fi
+
   if [ -n "$CHROOT_VARIABLES" ] ; then
     einfo "Removing ${CHROOT_VARIABLES}" ; rm "$CHROOT_VARIABLES" || eend $?
   fi
@@ -377,32 +416,77 @@ stage() {
   fi
 }
 
-# generates a single random byte, mostly to work around the fact that $RANDOM
-# returns 15 bits of output rather than 16
+# inverse-decrements ID_DERIVE_IDX, then xor's it with SOURCE_DATE_EPOCH to
+# get a seed number for generating reproducible pseudorandom IDs
+get_seed_from_sde() {
+  local mask seed_target
+
+  seed_target="${1:-}"
+
+  (( mask = 0x4000000000000000 ))
+
+  while [ "${mask}" -gt 0 ] && ! (( ID_DERIVE_IDX & mask )) ; do
+    (( ID_DERIVE_IDX |= mask ))
+    (( mask = mask >> 1 ))
+  done
+  (( ID_DERIVE_IDX &= (mask ^ 0x7fffffffffffffff) ))
+
+  printf -v "${seed_target}" '%s' "$(( SOURCE_DATE_EPOCH ^ ID_DERIVE_IDX ))"
+}
+
+# given a seed and byte count, generates a list of pseudrandom hexadecimal
+# bytes
+gen_random_hex_bytes() {
+  local seed count
+
+  # Bash's $RANDOM can be seeded with any integer Bash considers valid, but it
+  # truncates values and wraps around very quickly. We therefore use Perl
+  # to generate random bytes instead.
+
+  seed="${1:-}"
+  count="${2:-}"
+  if [ -z "${seed}" ] || ! [[ "${seed}" =~ ^[0-9]+$ ]]; then
+    eerror "No seed or invalid seed given to gen_random_hex_bytes!"
+    bailout 1
+  fi
+  if [ -z "${count}" ] || ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+    eerror "No count or invalid count given to gen_random_hex_bytes!"
+    bailout 1
+  fi
+
+  readarray -t RANDOM_HEX_BYTES_LIST < <(python3 -c \
+    'import sys, random; r = random.Random(int(sys.argv[1])); bytes = r.randbytes(int(sys.argv[2])); print(bytes.hex("\n"))' \
+    "${seed}" "${count}")
+  RANDOM_HEX_BYTE_IDX=0
+}
+
+# gets the next random hex value from RANDOM_HEX_BYTES_LIST
 get_random_hex_byte() {
   if [ -z "${1:-}" ]; then
     eerror 'No target var name provided to get_random_hex_byte!'
     bailout 1
   fi
-  printf -v "${1:-}" '%02x' "$(( RANDOM >> 7 ))"
-}
-
-mbr_id_from_seed() {
-  local seed target_var_name mbr_id_str rand_byte idx_a
-
-  seed="${1:-}"
-  target_var_name="${2:-}"
-
-  if [ -z "${seed}" ] || ! [[ "${seed}" =~ ^[0-9]+$ ]]; then
-    eerror 'No seed provided to mbr_id_from_seed!'
+  if [ "${RANDOM_HEX_BYTE_IDX}" -ge "${#RANDOM_HEX_BYTES_LIST[@]}" ]; then
+    eerror 'Out of random hex bytes!'
     bailout 1
   fi
+  printf -v "${1:-}" '%s' "${RANDOM_HEX_BYTES_LIST[RANDOM_HEX_BYTE_IDX]}"
+  (( RANDOM_HEX_BYTE_IDX += 1 )) || true
+}
+
+# creates an MBR disk identifier from SOURCE_DATE_EPOCH
+mbr_id_from_sde() {
+  local target_var_name mbr_id_str rand_byte idx_a seed
+
+  target_var_name="${1:-}"
+
   if [ -z "${target_var_name}" ]; then
     eerror 'No target var name provided to mbr_id_from_seed!'
     bailout 1
   fi
 
-  RANDOM="${seed}"
+  get_seed_from_sde seed
+  gen_random_hex_bytes "${seed}" 4
   mbr_id_str='0x'
 
   for idx_a in {1..4}; do
@@ -413,18 +497,13 @@ mbr_id_from_seed() {
   printf -v "${target_var_name}" '%s' "${mbr_id_str}"
 }
 
-# given a seed number and component count, creates a UUID or UUID prefix
-uuid_from_seed() {
-  local seed component_count target_var_name uuid_str rand_byte idx_a idx_b
+# creates a UUID or UUID prefix from SOURCE_DATE_EPOCH
+uuid_from_sde() {
+  local component_count target_var_name uuid_str rand_byte idx_a idx_b seed
 
-  seed="${1:-}"
-  component_count="${2:-}"
-  target_var_name="${3:-}"
+  component_count="${1:-}"
+  target_var_name="${2:-}"
 
-  if [ -z "${seed}" ] || ! [[ "${seed}" =~ ^[0-9]+$ ]]; then
-    eerror 'No seed provided to uuid_from_seed!'
-    bailout 1
-  fi
   if [ -z "${component_count}" ] \
     || ! [[ "${component_count}" =~ ^[0-9]+$ ]] \
     || [ "${component_count}" -gt 5 ] \
@@ -437,7 +516,8 @@ uuid_from_seed() {
     bailout 1
   fi
 
-  RANDOM="${seed}"
+  get_seed_from_sde seed
+  gen_random_hex_bytes "${seed}" 16
   uuid_str=''
 
   for idx_a in {1..4}; do
@@ -447,6 +527,7 @@ uuid_from_seed() {
 
   for (( idx_a = 1; idx_a < component_count; idx_a++ )); do
     uuid_str+='-'
+    # shellcheck disable=SC2034
     for idx_b in {1..2}; do
       get_random_hex_byte rand_byte
       uuid_str+="${rand_byte}"
@@ -463,6 +544,51 @@ uuid_from_seed() {
   fi
 
   printf -v "${target_var_name}" '%s' "${uuid_str}"
+}
+
+# insecurely creates a yescrypt-compatible password salt from
+# SOURCE_DATE_EPOCH
+insecure_password_salt_from_sde() {
+  local target_var_name salt_str hex_str rand_byte rand_val base64_digits \
+    gen_idx gen_sub_idx seed
+
+  target_var_name="${1:-}"
+
+  if [ -z "${target_var_name}" ]; then
+    eerror 'No target var name provided to insecure_password_salt_from_sde!'
+    bailout 1
+  fi
+
+  get_seed_from_sde seed
+  gen_random_hex_bytes "${seed}" 24
+  salt_str=''
+  rand_byte=''
+  rand_val=''
+  base64_digits='./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
+  # yescrypt's salt is in base 64, each digit carries 6 bits of information.
+  # get_random_hex_byte returns 8 bits of information per call, so we generate
+  # data 24 bits at a time, bulting up a 192-bit salt. yescrypt supports
+  # between 128 bit and 512 bit salts. The actual strength of this salt is
+  # 63 bits **at best** since we derive it from a 63-bit timestamp, and
+  # because it's derived from a timestamp, it's safe to assume this is as
+  # secure as no salt at all. In practice though, this might be marginally
+  # more secure than no salt.
+
+  for (( gen_idx = 0; gen_idx < 8; gen_idx++ )); do
+    hex_str=''
+    for (( gen_sub_idx = 0; gen_sub_idx < 3; gen_sub_idx++ )); do
+      get_random_hex_byte rand_byte
+      hex_str+="${rand_byte}"
+    done
+    (( rand_val = "0x${hex_str}" )) || true # converts hex to decimal
+    for (( gen_sub_idx = 0; gen_sub_idx < 4; gen_sub_idx++ )); do
+      salt_str+="${base64_digits:$((rand_val % 64)):1}"
+      (( rand_val /= 64 )) || true
+    done
+  done
+
+  printf -v "${target_var_name}" '%s' "${salt_str}"
 }
 # }}}
 
@@ -828,20 +954,55 @@ fi
   exit 0
 }
 
-if [ "${FIXED_DISK_IDENTIFIERS}" = 'yes' ]; then
-  if [ -z "${SOURCE_DATE_EPOCH}" ] \
-    || ! [[ "${SOURCE_DATE_EPOCH}" =~ ^[0-9]+$ ]]; then
-    SOURCE_DATE_EPOCH="$(date +%s)"
-    ewarn "FIXED_DISK_IDENTIFIERS is set to 'yes', but the SOURCE_DATE_EPOCH setting is not set. Defaulting to the current time (${SOURCE_DATE_EPOCH})."
+if [ -v SOURCE_DATE_EPOCH ] ; then
+  if [ -z "${SOURCE_DATE_EPOCH}" ] ; then
+    eerror "SOURCE_DATE_EPOCH is set but empty. Please unset it or set it to a decimal integer."
+    bailout 1
+  fi
+  if ! [[ "${SOURCE_DATE_EPOCH}" =~ ^[1-9][0-9]*$ ]] ; then
+    eerror "SOURCE_DATE_EPOCH is set to '${SOURCE_DATE_EPOCH}' but is not a decimal integer. Please unset it or set it to a decimal integer."
+    bailout 1
+  fi
+  # Bash only supports 64-bit signed integers; if SOURCE_DATE_EPOCH is greater
+  # than INT64_MAX, it will wrap around and become negative (or if it's so big
+  # that it becomes positive again, it will be longer than 19 digits).
+  if [ "${#SOURCE_DATE_EPOCH}" -gt 19 ] || (( SOURCE_DATE_EPOCH < 0 )) ; then
+    eerror "SOURCE_DATE_EPOCH is larger than INT64_MAX. Please unset it or set it to a smaller decimal integer."
+    bailout 1
+  fi
+  if [ "${SOURCE_DATE_EPOCH}" -gt "$(date +%s)" ]; then
+    eerror "SOURCE_DATE_EPOCH is in the future, which prevents downloading reproducible packages. Please set it to an earlier time."
+    bailout 1
+  fi
+  if [ "${MKFS}" != 'mkfs.ext4' ] ; then
+    eerror "SOURCE_DATE_EPOCH is set, but MKFS is not mkfs.ext4. Reproducible builds are only supported when using ext4."
+    bailout 1
+  fi
+  if [ "${USE_DEFAULT_INTERFACES}" != 'true' ]; then
+    eerror "SOURCE_DATE_EPOCH is set, but --defaultinterfaces was not passed! The resulting image would not be reproducible. Please add --defaultinterfaces to your command line."
+    bailout 1
+  fi
+  if [ "$HOSTNAME" = "$(hostname)" ]; then
+    ewarn "Attempting a reproducible build, but the image hostname is the same as the build host's. The image may not be reproducible."
   fi
 
-  mbr_id_from_seed "${SOURCE_DATE_EPOCH}" MBR_IDENTIFIER
-  uuid_from_seed "${SOURCE_DATE_EPOCH}" 5 FS_IDENTIFIER
-  # The GPT partition identifer shouldn't be the similar to the FS identifier.
-  # To avoid confusion if multiple builds are kicked off in quick succession,
-  # it shouldn't be based on SOURCE_DATE_EPOCH + 1 either.
-  uuid_from_seed "$(( SOURCE_DATE_EPOCH ^ 0x0fffffffffffffff ))" 4 \
-    GPT_IDENTIFIER_PREFIX
+  SOURCE_DATE_EPOCH_PRETTY="$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH}" \
+    '+%Y%m%dT%H%M%SZ')"
+
+  # Probably unnecessary, but just in case...
+  export SOURCE_DATE_EPOCH
+
+  uuid_from_sde 5 FS_IDENTIFIER
+  uuid_from_sde 5 FS_HASH_SEED
+  uuid_from_sde 4 GPT_IDENTIFIER_PREFIX
+  mbr_id_from_sde MBR_IDENTIFIER
+  if [ "${ROOTPASSWORD_SALT}" = '0' ] ; then
+    ewarn "Reproducible builds are enabled but ROOTPASSWORD_SALT is not set! This may be a security risk!"
+    insecure_password_salt_from_sde ROOTPASSWORD_SALT
+  elif ! [[ "${ROOTPASSWORD_SALT}" =~ ^[./A-Za-z0-9]{1,86}$ ]]; then
+    eerror "The value of ROOTPASSWORD_SALT is invalid!"
+    bailout 1
+  fi
 fi
 # }}}
 
@@ -857,6 +1018,14 @@ check4progs mmdebstrap || bailout 1
 
 if [ -n "$VIRTUAL" ] ; then
   check4progs kpartx parted qemu-img || bailout 1
+fi
+
+if [ -v SOURCE_DATE_EPOCH ] ; then
+  check4progs python3 mcopy mdir || bailout 1
+  if ! check_mke2fs_version; then
+    eerror "Reproducible builds require e2fsprogs >= 1.47.1!"
+    bailout 1
+  fi
 fi
 # }}}
 
@@ -1185,21 +1354,34 @@ if [ -n "$INTERACTIVE" ] ; then
    INFOTEXT="Please recheck configuration before execution:
    "
    [ -n "$TARGET" ]  && INFOTEXT="$INFOTEXT
-   Target:          $TARGET"
+   Target:                $TARGET"
    [ -n "$GRUB" ]    && INFOTEXT="$INFOTEXT
-   Install grub:    $GRUB"
+   Install grub:          $GRUB"
    [ -n "$EFI" ]    && INFOTEXT="$INFOTEXT
-   Install efi:     $EFI"
+   Install efi:           $EFI"
    [ -n "$RELEASE" ] && INFOTEXT="$INFOTEXT
-   Using release:   $RELEASE"
+   Using release:         $RELEASE"
    [ -n "$HOSTNAME" ] && INFOTEXT="$INFOTEXT
-   Using hostname:  $HOSTNAME"
+   Using hostname:        $HOSTNAME"
    [ -n "$MIRROR" ]  && INFOTEXT="$INFOTEXT
-   Using mirror:    $MIRROR"
+   Using mirror:          $MIRROR"
+   [ -n "$SECURITY_MIRROR" ]  && INFOTEXT="$INFOTEXT
+   Using security mirror: $SECURITY_MIRROR"
    [ -n "$ARCH" ]  && INFOTEXT="$INFOTEXT
-   Using arch:      $ARCH"
+   Using arch:            $ARCH"
    [ -n "$CONFFILES" ] && INFOTEXT="$INFOTEXT
-   Config files:    $CONFFILES"
+   Config files:          $CONFFILES"
+   if [ -v SOURCE_DATE_EPOCH ]; then
+     INFOTEXT="$INFOTEXT
+   Reproducible build:    yes"
+     INFOTEXT="$INFOTEXT
+   Final mirror:          ${FINAL_MIRROR:-${MIRROR}}"
+     INFOTEXT="$INFOTEXT
+   Final security mirror: ${FINAL_SECURITY_MIRROR:-${SECURITY_MIRROR}}"
+   else
+     INFOTEXT="$INFOTEXT
+   Reproducible build:    no"
+   fi
 
    INFOTEXT="$INFOTEXT
 
@@ -1214,21 +1396,34 @@ else # if not running automatic installation display configuration and prompt fo
    echo "   Target:          $TARGET"
 
    # do not display if MNTPOINT is the default one
-   case "$MNTPOINT" in /mnt/debootstrap*) ;; *) echo "   Mount point:     $MNTPOINT" ;; esac
+   case "$MNTPOINT" in
+     /mnt/debootstrap*) ;;
+     *)                   echo "   Mount point:           $MNTPOINT" ;;
+   esac
 
    if [ -n "$VIRTUAL" ] && [ "$GRUB_INSTALL" = 'yes' ] ; then
-      echo "   Install grub:    yes"
-      [ -n "$VMEFI" ]   && echo "   Install efi:     yes"   || echo "   Install efi:     no"
+                          echo "   Install grub:          yes"
+      [ -n "$VMEFI" ]  && echo "   Install efi:           yes"   \
+                       || echo "   Install efi:           no"
    else
-     [ -n "$GRUB" ]     && echo "   Install grub:    $GRUB" || echo "   Install grub:    no"
-     [ -n "$EFI" ]      && echo "   Install efi:     $EFI"  || echo "   Install efi:     no"
+     [ -n "$GRUB" ]    && echo "   Install grub:          $GRUB" \
+                       || echo "   Install grub:          no"
+     [ -n "$EFI" ]     && echo "   Install efi:           $EFI"  \
+                       || echo "   Install efi:           no"
    fi
 
-   [ -n "$RELEASE" ]   && echo "   Using release:   $RELEASE"
-   [ -n "$HOSTNAME" ]  && echo "   Using hostname:  $HOSTNAME"
-   [ -n "$MIRROR" ]    && echo "   Using mirror:    $MIRROR"
-   [ -n "$ARCH" ]      && echo "   Using arch:      $ARCH"
-   [ -n "$CONFFILES" ] && echo "   Config files:    $CONFFILES"
+   [ -n "$RELEASE" ]   && echo "   Using release:         $RELEASE"
+   [ -n "$HOSTNAME" ]  && echo "   Using hostname:        $HOSTNAME"
+   [ -n "$MIRROR" ]    && echo "   Using mirror:          $MIRROR"
+   [ -n "$ARCH" ]      && echo "   Using arch:            $ARCH"
+   [ -n "$CONFFILES" ] && echo "   Config files:          $CONFFILES"
+   if [ -v SOURCE_DATE_EPOCH ]; then
+                          echo "   Reproducible build:    yes"
+                          echo "   Final mirror:          ${FINAL_MIRROR:-${MIRROR}}"
+                          echo "   Final security mirror: ${FINAL_SECURITY_MIRROR:-${SECURITY_MIRROR}}"
+   else
+                          echo "   Reproducible build:    no"
+   fi
    if [ -n "$VIRTUAL" ] ; then
       echo "   Deploying as Virtual Machine."
       if [ -n "$IMAGESIZE" ] && [ -n "$IMAGEFILE" ]; then
@@ -1314,6 +1509,16 @@ if [[ "$ARCH" != "amd64" ]] && [[ "$ARCH" != "arm64" ]] ; then
 fi
 # }}}
 
+# Detect if a firmware boot partition is going to exist (for reproducible builds). {{{
+if [ -n "${EFI}" ] \
+  || [ "${VMEFI}" = '1' ] \
+  || [ -n "${RPIFIRM}" ] \
+  || [ "${RPI}" = '1' ] \
+  || [ "${ARCH}" = 'arm64' ] ; then
+  HAS_FWBOOT_PART='yes'
+fi
+# }}}
+
 # Support for generic release codenames is unavailable. {{{
 if [ "$RELEASE" = "stable" ] || [ "$RELEASE" = "testing" ] ; then
    eerror "Generic release codenames (stable, testing) are unsupported. \
@@ -1322,10 +1527,23 @@ Please use specific codenames such as bookworm or trixie."
 fi
 # }}}
 
-# Verify that provided GRUB device actually exists{{{
+# Verify that provided GRUB device actually exists {{{
 if [ -n "${GRUB}" ] && ! [ -b "${GRUB}" ] ;  then
   eerror "GRUB target '${GRUB}' doesn't look like a supported block device."
   bailout 1
+fi
+# }}}
+
+# Use snapshot mirrors for reproducible builds {{{
+if [ -v SOURCE_DATE_EPOCH ]; then
+  if ! [[ "${MIRROR}" =~ ^file: ]]; then
+    FINAL_MIRROR="$MIRROR"
+    MIRROR="${SNAPSHOT_ARCHIVE}/debian/${SOURCE_DATE_EPOCH_PRETTY}"
+  fi
+  if ! [[ "${SECURITY_MIRROR}" =~ ^file: ]]; then
+    FINAL_SECURITY_MIRROR="$SECURITY_MIRROR"
+    SECURITY_MIRROR="${SNAPSHOT_ARCHIVE}/debian-security/${SOURCE_DATE_EPOCH_PRETTY}"
+  fi
 fi
 # }}}
 checkconfiguration
@@ -1407,20 +1625,18 @@ mkfs() {
     esac
   fi
 
+  if [ -v SOURCE_DATE_EPOCH ] ; then
+    # MKFS is guaranteed to be mkfs.ext4. reimage_root_filesystem will rebuild
+    # the filesystem we generate here, so we don't technically need to set
+    # these here, but reimage_root_filesystem will reuse MKFS_OPTS and there's
+    # no real reason to not set it here.
+    MKFS_OPTS="$MKFS_OPTS -E hash_seed=${FS_HASH_SEED} -U ${FS_IDENTIFIER}"
+  fi
+
   if [ -n "$MKFS" ] ; then
     einfo "Running $MKFS $MKFS_OPTS on $TARGET"
     # shellcheck disable=SC2086
     "$MKFS" $MKFS_OPTS "$TARGET"
-
-    if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
-      if ! echo "$MKFS" | grep -q "mkfs.ext" ; then
-        eerror "Not changing disk uuid for $TARGET because $MKFS doesn't seem to match for ext{2,3,4} file system"
-        bailout 1
-      else
-        einfo "Changing disk uuid for $TARGET to fixed (non-random) value $FS_IDENTIFIER using tune2fs"
-        tune2fs "$TARGET" -U "$FS_IDENTIFIER" </dev/null
-      fi
-    fi
 
     if [ -n "$VIRTUAL" ] && [ -n "$EFI_TARGET" ]; then
       einfo "Creating FAT filesystem on $EFI_TARGET"
@@ -1660,7 +1876,7 @@ prepare_image() {
     parted -s "${TARGET}" 'set 1 boot on'
   fi
 
-  if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
+  if [ -v SOURCE_DATE_EPOCH ] ; then
     make_disk_ids_deterministic
   fi
 
@@ -1713,21 +1929,125 @@ prepare_image() {
 }
 # }}}
 
-# unmount VM image {{{
-umount_target() {
-  if [ -z "${VIRTUAL}" ] ; then
-     return 0
+# rebuild the firmware boot partition deterministically {{{
+make_fwboot_part_reproducible() {
+  local reimage_parent fwboot_part fwboot_name fwboot_object
+
+  if [ "${HAS_FWBOOT_PART}" = 'no' ]; then
+    return 0
   fi
 
-  try_umount 3 "${MNTPOINT}"/boot/efi
-
-  try_umount 3 "${MNTPOINT}"
-  kpartx -d "${ORIG_TARGET}" >/dev/null
-  # Workaround for a bug in kpartx which doesn't clean up properly,
-  # see Debian Bug #891077 and Github-PR grml/grml-debootstrap#112
-  if dmsetup ls | grep -q "^${LOOP_PART} "; then
-    kpartx -d "/dev/${LOOP_DISK}" >/dev/null
+  # TMPDIR might be cramped if it's on a tmpfs, try to use the same disk we're
+  # generating an image on if possible
+  if [ -f "${ORIG_TARGET:-}" ]; then
+    reimage_parent="$(dirname "${ORIG_TARGET}")"
+  else
+    reimage_parent="${TMPDIR:-/tmp}"
   fi
+  FWBOOT_REIMAGE_TREE="$(mktemp -d -p "${reimage_parent}")"
+
+  if [ -n "${EFI}" ] ; then
+    fwboot_part="${EFI}"
+    fwboot_name='EFI'
+  elif [ -n "${RPIFIRM}" ] ; then
+    fwboot_part="${RPIFIRM}"
+    fwboot_name='RPIFIRM'
+  else
+    eerror "Firmware boot partition expected but seems to not exist!"
+    bailout 1
+  fi
+
+  # Copy all files from the firmware boot partition to the reimage tree.
+  mcopy -i "${fwboot_part}" -s '::/.' "${FWBOOT_REIMAGE_TREE}/"
+  if [ -z "$(ls -A "${FWBOOT_REIMAGE_TREE}")" ]; then
+    eerror "No firmware boot files extracted from '${fwboot_part}'!"
+    bailout 1
+  fi
+
+  # Set the modification date for all files to SOURCE_DATE_EPOCH. `mcopy -m`
+  # will use this date for all file timestamps, including birth and access
+  # times.
+  find "${FWBOOT_REIMAGE_TREE}" -exec touch -d "@${SOURCE_DATE_EPOCH}" '{}' +
+
+  # Cluster slack may interfere with reproducibility, so erase the partition
+  # and rebuild it from scratch.
+  blkdiscard -f --zeroout "${fwboot_part}"
+  mkfs.fat -F32 -n "${fwboot_name}" "${fwboot_part}"
+
+  # `mcopy -i "${fwboot_part}" path/to/dir/. ::/` results in an error,
+  # "Cannot create entry named . or ..". We have to copy the files and dirs
+  # back one at a time.
+  for fwboot_object in \
+    "${FWBOOT_REIMAGE_TREE}"/* \
+    "${FWBOOT_REIMAGE_TREE}"/.* ; do
+    case "${fwboot_object##*/}" in
+      '.'|'..'|'*'|'.*') continue ;;
+    esac
+    if ! [ -e "${fwboot_object}" ]; then
+      # This shouldn't ever happen...
+      continue
+    fi
+    mcopy -i "${fwboot_part}" -s -m "${fwboot_object}" '::/'
+  done
+
+  rm -rf "${FWBOOT_REIMAGE_TREE}"
+  FWBOOT_REIMAGE_TREE=''
+}
+# }}}
+
+# save a snapshot of all files on the root filesystem {{{
+snapshot_root_filesystem() {
+  local reimage_parent
+
+  # This function has to be separate from the reimage_root_filesystem since
+  # this runs before the root filesystem is unmounted, while
+  # reimage_root_filesystem runs after.
+  #
+  # TMPDIR might be cramped if it's on a tmpfs, try to use the same disk we're
+  # generating an image on if possible
+  if [ -f "${ORIG_TARGET:-}" ]; then
+    reimage_parent="$(dirname "${ORIG_TARGET}")"
+  else
+    reimage_parent="${TMPDIR:-/tmp}"
+  fi
+  ROOTFS_REIMAGE_TREE="$(mktemp -d -p "${reimage_parent}")"
+
+  cp -a --one-file-system "${MNTPOINT}/." "${ROOTFS_REIMAGE_TREE}/"
+  if [ -z "$(ls -A "${ROOTFS_REIMAGE_TREE}")" ] ; then
+    eerror "Root filesystem snapshot from '${MNTPOINT}' is empty!"
+    bailout 1
+  fi
+}
+# }}}
+
+# re-image the root filesystem deterministically from the snapshot {{{
+reimage_root_filesystem() {
+  local current_uuid
+
+  if [ -z "${ROOTFS_REIMAGE_TREE}" ] \
+    || ! [ -d "${ROOTFS_REIMAGE_TREE}" ] ; then
+    return 0
+  fi
+
+  current_uuid="$(blkid -o value -s UUID "${TARGET}" 2>/dev/null || true)"
+  if [ "${current_uuid}" != "${FS_IDENTIFIER}" ] ; then
+    eerror "Root filesystem UUID '${current_uuid}' does not match FS_IDENTIFIER '${FS_IDENTIFIER}', reimaging the root filesystem would render the installation unbootable!"
+    bailout 1
+  fi
+
+  # Make sure to only pass -F once. This will keep mkfs.ext4 from overwriting
+  # the filesystem if it is mounted somewhere already.
+  local force_maybe
+  if printf '%s' "${MKFS_OPTS}" | grep -qw -- '-F'; then
+    force_maybe=()
+  else
+    force_maybe=( '-F' )
+  fi
+  # shellcheck disable=SC2086
+  "${MKFS}" ${MKFS_OPTS} -d "${ROOTFS_REIMAGE_TREE}" "${force_maybe[@]}" "${TARGET}"
+  rm -rf "${ROOTFS_REIMAGE_TREE}"
+  ROOTFS_REIMAGE_TREE=''
+  tunefs
 }
 # }}}
 
@@ -1749,10 +2069,13 @@ debootstrap_system() {
   # Support https mirrors.
   bootstrap_include='--include=ca-certificates'
 
+  local -a bootstrap_aptopt=()
+  [ -v SOURCE_DATE_EPOCH ] && bootstrap_aptopt+=( '--aptopt=Acquire::Check-Valid-Until "false"' )
+
   einfo "Running mmdebstrap $DEBOOTSTRAP_OPT for release ${RELEASE}${ARCHINFO} using ${MIRROR}"
-  einfo "Executing: mmdebstrap --skip=cleanup/apt --skip=check/empty $bootstrap_include $ARCHCMD $DEBOOTSTRAP_OPT $RELEASE $MNTPOINT $MIRROR"
+  einfo "Executing: mmdebstrap --skip=cleanup/apt --skip=check/empty ${bootstrap_aptopt[*]} $bootstrap_include $ARCHCMD $DEBOOTSTRAP_OPT $RELEASE $MNTPOINT $MIRROR"
   # shellcheck disable=SC2086
-  mmdebstrap --skip=cleanup/apt --skip=check/empty "$bootstrap_include" $ARCHCMD $DEBOOTSTRAP_OPT "$RELEASE" "$MNTPOINT" "$MIRROR"
+  mmdebstrap --skip=cleanup/apt --skip=check/empty "${bootstrap_aptopt[@]}" "$bootstrap_include" $ARCHCMD $DEBOOTSTRAP_OPT "$RELEASE" "$MNTPOINT" "$MIRROR"
 }
 # }}}
 
@@ -1817,7 +2140,10 @@ preparechroot() {
   [ -n "$EXTRAPACKAGES" ]             && echo "EXTRAPACKAGES='${EXTRAPACKAGES//\'/\'\\\'\'}'"                       >> "$CHROOT_VARIABLES"
   [ -n "$EFI" ]                       && echo "EFI='${EFI//\'/\'\\\'\'}'"                                           >> "$CHROOT_VARIABLES"
   [ -n "$FALLBACK_MIRROR" ]           && echo "FALLBACK_MIRROR='${FALLBACK_MIRROR//\'/\'\\\'\'}'"                   >> "$CHROOT_VARIABLES"
+  [ -n "$FALLBACK_SECURITY_MIRROR" ]  && echo "FALLBACK_SECURITY_MIRROR='${FALLBACK_SECURITY_MIRROR//\'/\'\\\'\'}'" >> "$CHROOT_VARIABLES"
   [ -n "$FILESYSTEM" ]                && echo "FILESYSTEM='${FILESYSTEM//\'/\'\\\'\'}'"                             >> "$CHROOT_VARIABLES"
+  [ -n "$FINAL_MIRROR" ]              && echo "FINAL_MIRROR='${FINAL_MIRROR//\'/\'\\\'\'}'"                         >> "$CHROOT_VARIABLES"
+  [ -n "$FINAL_SECURITY_MIRROR" ]     && echo "FINAL_SECURITY_MIRROR='${FINAL_SECURITY_MIRROR//\'/\'\\\'\'}'"       >> "$CHROOT_VARIABLES"
   [ -n "$FORCE" ]                     && echo "FORCE='${FORCE//\'/\'\\\'\'}'"                                       >> "$CHROOT_VARIABLES"
   [ -n "$GRMLREPOS" ]                 && echo "GRMLREPOS='${GRMLREPOS//\'/\'\\\'\'}'"                               >> "$CHROOT_VARIABLES"
   [ -n "$GRUB" ]                      && echo "GRUB='${GRUB//\'/\'\\\'\'}'"                                         >> "$CHROOT_VARIABLES"
@@ -1838,13 +2164,16 @@ preparechroot() {
   [ -n "$PRE_SCRIPTS" ]               && echo "PRE_SCRIPTS='${PRE_SCRIPTS//\'/\'\\\'\'}'"                           >> "$CHROOT_VARIABLES"
   [ -n "$RECONFIGURE" ]               && echo "RECONFIGURE='${RECONFIGURE//\'/\'\\\'\'}'"                           >> "$CHROOT_VARIABLES"
   [ -n "$RELEASE" ]                   && echo "RELEASE='${RELEASE//\'/\'\\\'\'}'"                                   >> "$CHROOT_VARIABLES"
-  [ -n "$RPI" ]                        && echo "RPI='${RPI}'"                                                       >> "$CHROOT_VARIABLES"
+  [ -n "$RPI" ]                       && echo "RPI='${RPI}'"                                                        >> "$CHROOT_VARIABLES"
   [ -n "$RPIFIRM" ]                   && echo "RPIFIRM='${RPIFIRM//\'/\'\\\'\'}'"                                   >> "$CHROOT_VARIABLES"
   [ -n "$RM_APTCACHE" ]               && echo "RM_APTCACHE='${RM_APTCACHE//\'/\'\\\'\'}'"                           >> "$CHROOT_VARIABLES"
   [ -n "$ROOTPASSWORD" ]              && echo "ROOTPASSWORD='${ROOTPASSWORD//\'/\'\\\'\'}'"                         >> "$CHROOT_VARIABLES"
+  [ -n "$ROOTPASSWORD_SALT" ]         && echo "ROOTPASSWORD_SALT='${ROOTPASSWORD_SALT//\'/\'\\\'\'}'"               >> "$CHROOT_VARIABLES"
   [ -n "$SCRIPTS" ]                   && echo "SCRIPTS='${SCRIPTS//\'/\'\\\'\'}'"                                   >> "$CHROOT_VARIABLES"
   [ -n "$SECURE" ]                    && echo "SECURE='${SECURE//\'/\'\\\'\'}'"                                     >> "$CHROOT_VARIABLES"
+  [ -n "$SECURITY_MIRROR" ]           && echo "SECURITY_MIRROR='${SECURITY_MIRROR//\'/\'\\\'\'}'"                   >> "$CHROOT_VARIABLES"
   [ -n "$SELECTED_PARTITIONS" ]       && echo "SELECTED_PARTITIONS='${SELECTED_PARTITIONS//\'/\'\\\'\'}'"           >> "$CHROOT_VARIABLES"
+  [ -n "$SOURCE_DATE_EPOCH" ]         && echo "SOURCE_DATE_EPOCH='${SOURCE_DATE_EPOCH//\'/\'\\\'\'}'"               >> "$CHROOT_VARIABLES"
   [ -n "$TARGET" ]                    && echo "TARGET='${TARGET//\'/\'\\\'\'}'"                                     >> "$CHROOT_VARIABLES"
   [ -n "$UPGRADE_SYSTEM" ]            && echo "UPGRADE_SYSTEM='${UPGRADE_SYSTEM//\'/\'\\\'\'}'"                     >> "$CHROOT_VARIABLES"
   [ -n "$TARGET_UUID" ]               && echo "TARGET_UUID='${TARGET_UUID//\'/\'\\\'\'}'"                           >> "$CHROOT_VARIABLES"
@@ -2112,7 +2441,7 @@ chrootscript() {
 }
 # }}}
 
-# unmount $MNTPOINT {{{
+# unmount $MNTPOINT, tear down loop devices and reimage filesystems {{{
 umount_chroot() {
 
   # display installation notes:
@@ -2120,10 +2449,31 @@ umount_chroot() {
      [ -r "${MNTPOINT}/${INSTALL_NOTES}" ] && cat "${MNTPOINT}/${INSTALL_NOTES}"
   fi
 
+  try_umount 3 "${MNTPOINT}"/boot/efi
+  try_umount 3 "${MNTPOINT}"/boot/firmware
+  if [ -v SOURCE_DATE_EPOCH ] && [ "${HAS_FWBOOT_PART}" = 'yes' ] ; then
+    make_fwboot_part_reproducible
+  fi
+
   try_umount 3 "${MNTPOINT}"/run/udev
 
   if [ -n "$PARTITION" ] ; then
-     try_umount 3 "$MNTPOINT"
+    if [ -v SOURCE_DATE_EPOCH ] ; then
+      snapshot_root_filesystem
+    fi
+    try_umount 3 "$MNTPOINT"
+    if [ -v SOURCE_DATE_EPOCH ] ; then
+      reimage_root_filesystem
+    fi
+
+    if [ -n "${VIRTUAL}" ] || [ -n "$RPI" ] ; then
+      kpartx -d "${ORIG_TARGET}" >/dev/null
+      # Workaround for a bug in kpartx which doesn't clean up properly,
+      # see Debian Bug #891077 and Github-PR grml/grml-debootstrap#112
+      if dmsetup ls | grep -q "^${LOOP_PART} " ; then
+        kpartx -d "/dev/${LOOP_DISK}" >/dev/null
+      fi
+    fi
   fi
 }
 # }}}
@@ -2163,7 +2513,7 @@ remove_configs() {
 for i in format_fwboot_partitions prepare_image mkfs tunefs \
          mount_target mountpoint_to_blockdevice debootstrap_system \
          preparechroot execute_pre_scripts chrootscript execute_post_scripts \
-         remove_configs umount_chroot umount_target fscktool ; do
+         remove_configs umount_chroot fscktool ; do
     if stage "${i}" ; then
       "$i"
       stage "${i}" 'done'

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1251,7 +1251,7 @@ else # if not running automatic installation display configuration and prompt fo
      echo
      einfon "Is this ok for you? [y/N] "
      read -r a
-     if ! [ "$a" = 'y' ] || [ "$a" = 'Y' ] ; then
+     if [ "$a" != 'y' ] && [ "$a" != 'Y' ] ; then
         eerror "Exiting as requested."
         bailout 1
      fi

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -634,7 +634,7 @@ while :; do
   # == Other options
   --verbose|-v)        # Increase verbosity
     if [ "$_opt_verbose" ]; then
-      _opt_verbose=$( _opt_verbose + 1 )
+      _opt_verbose=$(( _opt_verbose + 1 ))
     else
       _opt_verbose=1
     fi

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -51,6 +51,8 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$DEFAULT_LANGUAGE" ] || DEFAULT_LANGUAGE='en_US:en'
 [ -n "$DEFAULT_LOCALES" ] || DEFAULT_LOCALES='en_US.UTF-8'
 [ -n "$FS_IDENTIFIER" ] || FS_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
+[ -n "$GPT_IDENTIFIER_PREFIX" ] || GPT_IDENTIFIER_PREFIX='b3170792-c1b6-4b84-b6ac'
+[ -n "$MBR_IDENTIFIER" ] || MBR_IDENTIFIER='0x41414141'
 [ -n "$EXTRAPACKAGES" ] || EXTRAPACKAGES='yes'
 [ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://deb.debian.org/debian'
 [ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
@@ -1443,6 +1445,39 @@ mount_target() {
 }
 # }}}
 
+# adjust disk and partition IDs to be deterministic {{{
+make_disk_ids_deterministic() {
+  einfo "Making disk IDs deterministic"
+  if [ -n "$VMEFI" ]; then
+    local part_number_list part_number gpt_id
+
+    # All of the partition numbers will probably be contiguous, but in theory
+    # there could be holes, so we get the list of partition numbers as
+    # reported by sfdisk instead of simply counting numbers.
+    #
+    # Partition ID lines contain a ' : ' near the beginning of the line. The
+    # space-separated word immediately before this substring has a decimal
+    # partition ID at the end of it.
+
+    readarray -t part_number_list < <(sfdisk -d -- "${TARGET}" \
+      | grep --only-matching '[^ ]\+ : ' | sed -n 's/.*\([0-9]\+\).*/\1/p')
+    sfdisk --disk-id "${TARGET}" "${GPT_IDENTIFIER_PREFIX}-000000000000"
+
+    for part_number in "${part_number_list[@]}"; do
+      printf -v gpt_id "%s-%012d" "${GPT_IDENTIFIER_PREFIX}" "${part_number}"
+      sfdisk --part-uuid "${TARGET}" "${part_number}" "${gpt_id}"
+    done
+
+    # Parted seems to use an MBR disk identifier of 0x00000000 for the
+    # protective MBR, but just in case, change it to match $MBR_IDENTIFIER
+    # anyway.
+    sfdisk --label-nested dos --disk-id "${TARGET}" "${MBR_IDENTIFIER}"
+  else
+    sfdisk --disk-id "${TARGET}" "${MBR_IDENTIFIER}"
+  fi
+}
+# }}}
+
 # prepare VM image for usage with debootstrap {{{
 prepare_image() {
   if [ -z "$VIRTUAL" ] && [ -z "$RPI" ]; then
@@ -1517,15 +1552,12 @@ prepare_image() {
     parted -s "${TARGET}" 'mkpart primary ext4 508MiB 100%'
   else
     parted -s "${TARGET}" 'mklabel msdos'
-    if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
-      einfo "Adjusting disk signature to a fixed (non-random) value"
-      MBRTMPFILE=$(mktemp)
-      dd if="${TARGET}" of="${MBRTMPFILE}" bs=512 count=1
-      echo -en "\\x41\\x41\\x41\\x41" | dd of="${MBRTMPFILE}" conv=notrunc seek=440 bs=1
-      dd if="${MBRTMPFILE}" of="${TARGET}" conv=notrunc
-    fi
     parted -s "${TARGET}" 'mkpart primary ext4 4MiB 100%'
     parted -s "${TARGET}" 'set 1 boot on'
+  fi
+
+  if [ "$FIXED_DISK_IDENTIFIERS" = "yes" ] ; then
+    make_disk_ids_deterministic
   fi
 
   DEVINFO=$(kpartx -asv "$TARGET") # e.g. 'add map loop0p1 (254:5): 0 20477 linear 7:0 3' - will be multi-line for EFI VMs

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -1809,6 +1809,7 @@ preparechroot() {
   [ -n "$CHROOT_SCRIPTS" ]            && echo "CHROOT_SCRIPTS='${CHROOT_SCRIPTS//\'/\'\\\'\'}'"                     >> "$CHROOT_VARIABLES"
   [ -n "$COMPONENTS" ]                && echo "COMPONENTS='${COMPONENTS//\'/\'\\\'\'}'"                             >> "$CHROOT_VARIABLES"
   [ -n "$CONFFILES" ]                 && echo "CONFFILES='${CONFFILES//\'/\'\\\'\'}'"                               >> "$CHROOT_VARIABLES"
+  [ -n "$DPKG_OPTIONS" ]              && echo "DPKG_OPTIONS='${DPKG_OPTIONS//\'/\'\\\'\'}'"                         >> "$CHROOT_VARIABLES"
   [ -n "$DEBCONF" ]                   && echo "DEBCONF='${DEBCONF//\'/\'\\\'\'}'"                                   >> "$CHROOT_VARIABLES"
   [ -n "$DEBIAN_FRONTEND" ]           && echo "DEBIAN_FRONTEND='${DEBIAN_FRONTEND//\'/\'\\\'\'}'"                   >> "$CHROOT_VARIABLES"
   [ -n "$DEFAULT_LOCALES" ]           && echo "DEFAULT_LOCALES='${DEFAULT_LOCALES//\'/\'\\\'\'}'"                   >> "$CHROOT_VARIABLES"

--- a/grml-debootstrap
+++ b/grml-debootstrap
@@ -50,9 +50,9 @@ MNTPOINT="/mnt/debootstrap.$$"
 [ -n "$DEBIAN_FRONTEND" ] || DEBIAN_FRONTEND='noninteractive'
 [ -n "$DEFAULT_LANGUAGE" ] || DEFAULT_LANGUAGE='en_US:en'
 [ -n "$DEFAULT_LOCALES" ] || DEFAULT_LOCALES='en_US.UTF-8'
-[ -n "$FS_IDENTIFIER" ] || FS_IDENTIFIER='26ada0c0-1165-4098-884d-aafd2220c2c6'
-[ -n "$GPT_IDENTIFIER_PREFIX" ] || GPT_IDENTIFIER_PREFIX='b3170792-c1b6-4b84-b6ac'
-[ -n "$MBR_IDENTIFIER" ] || MBR_IDENTIFIER='0x41414141'
+[ -n "$FS_IDENTIFIER" ] || FS_IDENTIFIER='00000000-0000-0000-0000-000000000000'
+[ -n "$GPT_IDENTIFIER_PREFIX" ] || GPT_IDENTIFIER_PREFIX='00000000-0000-0000-0000'
+[ -n "$MBR_IDENTIFIER" ] || MBR_IDENTIFIER='0x00000000'
 [ -n "$EXTRAPACKAGES" ] || EXTRAPACKAGES='yes'
 [ -n "$FALLBACK_MIRROR" ] || FALLBACK_MIRROR='http://deb.debian.org/debian'
 [ -n "$FIXED_DISK_IDENTIFIERS" ] || FIXED_DISK_IDENTIFIERS="no"
@@ -375,6 +375,94 @@ stage() {
      ewarn "  To reexecute it clean up the according directory inside $STAGES"
      return 1
   fi
+}
+
+# generates a single random byte, mostly to work around the fact that $RANDOM
+# returns 15 bits of output rather than 16
+get_random_hex_byte() {
+  if [ -z "${1:-}" ]; then
+    eerror 'No target var name provided to get_random_hex_byte!'
+    bailout 1
+  fi
+  printf -v "${1:-}" '%02x' "$(( RANDOM >> 7 ))"
+}
+
+mbr_id_from_seed() {
+  local seed target_var_name mbr_id_str rand_byte idx_a
+
+  seed="${1:-}"
+  target_var_name="${2:-}"
+
+  if [ -z "${seed}" ] || ! [[ "${seed}" =~ ^[0-9]+$ ]]; then
+    eerror 'No seed provided to mbr_id_from_seed!'
+    bailout 1
+  fi
+  if [ -z "${target_var_name}" ]; then
+    eerror 'No target var name provided to mbr_id_from_seed!'
+    bailout 1
+  fi
+
+  RANDOM="${seed}"
+  mbr_id_str='0x'
+
+  for idx_a in {1..4}; do
+    get_random_hex_byte rand_byte
+    mbr_id_str+="${rand_byte}"
+  done
+
+  printf -v "${target_var_name}" '%s' "${mbr_id_str}"
+}
+
+# given a seed number and component count, creates a UUID or UUID prefix
+uuid_from_seed() {
+  local seed component_count target_var_name uuid_str rand_byte idx_a idx_b
+
+  seed="${1:-}"
+  component_count="${2:-}"
+  target_var_name="${3:-}"
+
+  if [ -z "${seed}" ] || ! [[ "${seed}" =~ ^[0-9]+$ ]]; then
+    eerror 'No seed provided to uuid_from_seed!'
+    bailout 1
+  fi
+  if [ -z "${component_count}" ] \
+    || ! [[ "${component_count}" =~ ^[0-9]+$ ]] \
+    || [ "${component_count}" -gt 5 ] \
+    || [ "${component_count}" -lt 1 ]; then
+    eerror 'No (or invalid) component count provided to uuid_from_seed!'
+    bailout 1
+  fi
+  if [ -z "${target_var_name}" ]; then
+    eerror 'No target var name provided to uuid_from_seed!'
+    bailout 1
+  fi
+
+  RANDOM="${seed}"
+  uuid_str=''
+
+  for idx_a in {1..4}; do
+    get_random_hex_byte rand_byte
+    uuid_str+="${rand_byte}"
+  done
+
+  for (( idx_a = 1; idx_a < component_count; idx_a++ )); do
+    uuid_str+='-'
+    for idx_b in {1..2}; do
+      get_random_hex_byte rand_byte
+      uuid_str+="${rand_byte}"
+    done
+    [ "${idx_a}" -ge 3 ] && break;
+  done
+
+  if [ "${component_count}" -ge 5 ]; then
+    uuid_str+='-'
+    for idx_a in {1..6}; do
+      get_random_hex_byte rand_byte
+      uuid_str+="${rand_byte}"
+    done
+  fi
+
+  printf -v "${target_var_name}" '%s' "${uuid_str}"
 }
 # }}}
 
@@ -739,6 +827,22 @@ fi
   einfo "Report bugs via https://github.com/grml/grml-debootstrap/ or https://grml.org/bugs/"
   exit 0
 }
+
+if [ "${FIXED_DISK_IDENTIFIERS}" = 'yes' ]; then
+  if [ -z "${SOURCE_DATE_EPOCH}" ] \
+    || ! [[ "${SOURCE_DATE_EPOCH}" =~ ^[0-9]+$ ]]; then
+    SOURCE_DATE_EPOCH="$(date +%s)"
+    ewarn "FIXED_DISK_IDENTIFIERS is set to 'yes', but the SOURCE_DATE_EPOCH setting is not set. Defaulting to the current time (${SOURCE_DATE_EPOCH})."
+  fi
+
+  mbr_id_from_seed "${SOURCE_DATE_EPOCH}" MBR_IDENTIFIER
+  uuid_from_seed "${SOURCE_DATE_EPOCH}" 5 FS_IDENTIFIER
+  # The GPT partition identifer shouldn't be the similar to the FS identifier.
+  # To avoid confusion if multiple builds are kicked off in quick succession,
+  # it shouldn't be based on SOURCE_DATE_EPOCH + 1 either.
+  uuid_from_seed "$(( SOURCE_DATE_EPOCH ^ 0x0fffffffffffffff ))" 4 \
+    GPT_IDENTIFIER_PREFIX
+fi
 # }}}
 
 # check for root permissions {{{


### PR DESCRIPTION
There's still a lot of work to do on this (testing of various different installation scenarios and image types, adding CI tests, seeing if the same image can be generated by using the same parameters to grml-debootstrap on two *different* computers, etc.), but at this point. I'm able to build images back-to-back on the same system with the same parameters, and get two identical images as output. Getting this to work is tricky though, and there are a lot of caveats:

* `/etc/debootstrap/config` needs to have three settings set:
  * `KEEP_SRC_LIST=yes`
  * `MIRROR='/etc/debootstrap/etc/apt/sources.list.d/debian.sources` (`MIRROR` was never intended to take a file instead of a URL, but if one doesn't enable the backports repo and passes `KEEP_SRC_LIST='yes'`, the only place MIRROR ends up getting used is as an argument to mmdebstrap, and mmdebstrap *does* take a file as input for mirrors)
  * `SOURCE_DATE_EPOCH='...'` (set whatever time you want here)
* `/etc/debootstrap/etc/apt/sources.list.d/debian.sources` needs to be created with content similar to the following, to point it to whatever snapshots one wants from snapshot.debian.org:

```
Types: deb
URIs: https://snapshot.debian.org/archive/debian/20260727T202418Z/
Suites: trixie trixie-updates
Components: main contrib non-free non-free-firmware
Enabled: yes
Check-Valid-Until: no
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

Types: deb
URIs: https://snapshot.debian.org/archive/debian-security/20260726T121236Z/
Suites: trixie-security
Components: main contrib non-free non-free-firmware
Enabled: yes
Check-Valid-Until: no
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
```

* You can't use the `--backports` option, as it triggers a code path in `chroot-script` that assumes `MIRROR` is a URL.
* You can't use the `--grml` option, as this adds a non-snapshotted grml repo to the image.
* You can't use filesystems other than ext4. (This will probably be a long-term limitation, since the steps to get a reproducible filesystem image will vary from filesystem to filesystem.)
* This probably won't provide reproducibility *yet* if installing directly to a hardware device, since it relies on `mkfs.ext4` being able to fstrim the target device during filesystem reimaging, which simply won't work on some hardware devices.
* There are probably subtle bugs I'm missing.

Despite all the above though, if you set up everything as described above and then use a command like `sudo grml-debootstrap --vm --vmefi --vmfile --vmsize 2G --target ./vm.img --release trixie --password x --hostname reproducible-debian --force` to generate a VM image, you will *probably* get a reproducible image. I'll continue working on this, but I figured now was a good time to submit a draft PR.