### PR TITLE
debian/control drop dependency gawk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends:
  dosfstools,
  e2fsprogs,
  fdisk,
- gawk,
  kmod,
  mmdebstrap,
  ${misc:Depends},


### PR DESCRIPTION
We do not need explicit gawk since commit 43cc740ba83a2613c7ec3ed3c16e4c549d0f2372
